### PR TITLE
`nexrad-decode` summarization API, add common traits

### DIFF
--- a/nexrad-data/examples/archive.rs
+++ b/nexrad-data/examples/archive.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use log::{debug, info, trace, LevelFilter};
+use log::{debug, info, trace, warn, LevelFilter};
 
 #[cfg(not(all(feature = "aws", feature = "decode")))]
 fn main() {
@@ -29,7 +29,6 @@ struct Cli {
 #[cfg(all(feature = "aws", feature = "decode"))]
 #[tokio::main]
 async fn main() -> nexrad_data::result::Result<()> {
-    use chrono::Utc;
     use chrono::{NaiveDate, NaiveTime};
     use nexrad_data::aws::archive::{download_file, list_files};
     use nexrad_data::volume::File;
@@ -50,39 +49,38 @@ async fn main() -> nexrad_data::result::Result<()> {
         NaiveTime::parse_from_str(&cli.start_time, "%H:%M").expect("start is valid time");
     let stop_time = NaiveTime::parse_from_str(&cli.stop_time, "%H:%M").expect("stop is valid time");
 
-    println!("Listing files for {} on {}...", site, date);
+    info!("Listing files for {} on {}...", site, date);
     let file_ids = list_files(site, &date).await?;
 
     if file_ids.is_empty() {
-        println!("No files found for the specified date/site to download.");
+        warn!("No files found for the specified date/site to download.");
         return Ok(());
     }
 
-    println!("Found {} files.", file_ids.len());
+    debug!("Found {} files.", file_ids.len());
 
     let start_index = get_nearest_file_index(&file_ids, start_time);
-    println!(
+    debug!(
         "Nearest file to start of {:?} is {:?}.",
         start_time,
         file_ids[start_index].name()
     );
 
     let stop_index = get_nearest_file_index(&file_ids, stop_time);
-    println!(
+    debug!(
         "Nearest file to stop of {:?} is {:?}.",
         stop_time,
         file_ids[stop_index].name()
     );
 
-    println!("Downloading {} files...", stop_index - start_index + 1);
-
+    debug!("Downloading {} files...", stop_index - start_index + 1);
     for file_id in file_ids
         .iter()
         .skip(start_index)
         .take(stop_index - start_index + 1)
     {
         let file = if Path::new(&format!("downloads/{}", file_id.name())).exists() {
-            println!("File \"{}\" already downloaded.", file_id.name());
+            debug!("File \"{}\" already downloaded.", file_id.name());
             let mut file =
                 std::fs::File::open(format!("downloads/{}", file_id.name())).expect("open file");
 
@@ -91,21 +89,15 @@ async fn main() -> nexrad_data::result::Result<()> {
 
             File::new(buffer)
         } else {
-            println!("Downloading file \"{}\"...", file_id.name());
+            debug!("Downloading file \"{}\"...", file_id.name());
             let file = download_file(file_id.clone()).await?;
 
-            println!("Data file size (bytes): {}", file.data().len());
             if !Path::new("downloads").exists() {
-                println!("Creating downloads directory...");
+                trace!("Creating downloads directory...");
                 create_dir("downloads").expect("create downloads directory");
             }
 
-            if !Path::new("downloads").exists() {
-                println!("Creating downloads directory...");
-                create_dir("downloads").expect("create downloads directory");
-            }
-
-            println!("Writing file to disk as: {}", file_id.name());
+            trace!("Writing file to disk as: {}", file_id.name());
             let mut downloaded_file =
                 std::fs::File::create(format!("downloads/{}", file_id.name()))
                     .expect("create file");
@@ -117,21 +109,29 @@ async fn main() -> nexrad_data::result::Result<()> {
             file
         };
 
-        println!("Data file size (bytes): {}", file.data().len());
+        trace!("Data file size (bytes): {}", file.data().len());
 
         let records = file.records();
         debug!(
-            "Volume start chunk with {} records. Header: {:?}",
+            "Volume with {} records. Header: {:?}",
             records.len(),
             file.header()
         );
 
-        records
-            .into_iter()
-            .for_each(|record| decode_record(record, Utc::now()));
-    }
+        let mut messages = Vec::new();
+        for mut record in records {
+            debug!("Decoding record...");
+            if record.compressed() {
+                trace!("Decompressing LDM record...");
+                record = record.decompress().expect("Failed to decompress record");
+            }
 
-    println!("Downloaded {} files.", stop_index - start_index + 1);
+            messages.extend(record.messages()?.iter().cloned());
+        }
+
+        let summary = nexrad_decode::summarize::messages(messages.as_slice());
+        info!("Volume summary:\n{:#?}", summary);
+    }
 
     Ok(())
 }
@@ -167,143 +167,4 @@ fn get_nearest_file_index(
     }
 
     min_index
-}
-
-#[cfg(all(feature = "aws", feature = "decode"))]
-fn decode_record(
-    mut record: nexrad_data::volume::Record,
-    download_time: chrono::DateTime<chrono::Utc>,
-) {
-    use nexrad_decode::messages::MessageType;
-    use nexrad_decode::messages::{decode_messages, Message};
-    use std::collections::HashMap;
-    use std::io::Cursor;
-
-    if record.compressed() {
-        trace!("Decompressing LDM record...");
-        record = record.decompress().expect("Failed to decompress record");
-    } else {
-        trace!("Decompressed LDM record");
-    }
-
-    let mut message_type_counts = HashMap::new();
-
-    let mut all_scans = Vec::new();
-    let mut first_message_time = None;
-    let mut coverage_pattern = None;
-    let mut scan_data: Option<ScanData> = None;
-
-    let mut reader = Cursor::new(record.data());
-    let messages = decode_messages(&mut reader).expect("Failed to decode messages");
-    for message in messages {
-        let message_header = message.header;
-
-        if first_message_time.is_none() {
-            first_message_time = message_header.date_time();
-        }
-
-        let message_type = message_header.message_type();
-        let count = message_type_counts.get(&message_type).unwrap_or(&0) + 1;
-        message_type_counts.insert(message_type, count);
-
-        match message.message {
-            Message::DigitalRadarData(m31) => {
-                if coverage_pattern.is_none() {
-                    coverage_pattern = Some(
-                        m31.volume_data_block
-                            .expect("No volume data block")
-                            .volume_coverage_pattern_number,
-                    );
-                }
-
-                if let Some(current_scan_data) = scan_data.as_mut() {
-                    if current_scan_data.elevation == m31.header.elevation_number {
-                        current_scan_data.end_azimuth = m31.header.azimuth_angle;
-
-                        let mut increment_count = |data_type: &str| {
-                            let count =
-                                current_scan_data.data_types.get(data_type).unwrap_or(&0) + 1;
-                            current_scan_data
-                                .data_types
-                                .insert(data_type.to_string(), count);
-                        };
-
-                        if m31.reflectivity_data_block.is_some() {
-                            increment_count("Reflectivity");
-                        }
-                        if m31.velocity_data_block.is_some() {
-                            increment_count("Velocity");
-                        }
-                        if m31.spectrum_width_data_block.is_some() {
-                            increment_count("Spectrum Width");
-                        }
-                        if m31.differential_reflectivity_data_block.is_some() {
-                            increment_count("Differential Reflectivity");
-                        }
-                        if m31.differential_phase_data_block.is_some() {
-                            increment_count("Differential Phase");
-                        }
-                        if m31.correlation_coefficient_data_block.is_some() {
-                            increment_count("Correlation Coefficient");
-                        }
-                        if m31.specific_diff_phase_data_block.is_some() {
-                            increment_count("Specific Differential Phase");
-                        }
-                    } else {
-                        all_scans.push(format!("{}", current_scan_data));
-                        scan_data = None;
-                    }
-                }
-
-                if scan_data.is_none() {
-                    scan_data = Some(ScanData {
-                        start_azimuth: m31.header.azimuth_angle,
-                        end_azimuth: m31.header.azimuth_angle,
-                        elevation: m31.header.elevation_number,
-                        data_types: HashMap::new(),
-                    });
-                }
-            }
-            _ => {
-                if let Some(scan_data) = scan_data.take() {
-                    all_scans.push(format!("{}", scan_data));
-                }
-            }
-        }
-    }
-
-    if let Some(scan_info) = scan_data.take() {
-        all_scans.push(format!("{}", scan_info));
-    }
-
-    debug!(
-        "Message latency: {:?}, Coverage pattern: {:?}",
-        first_message_time.map(|time| download_time - time),
-        coverage_pattern
-    );
-
-    for (message_type, count) in message_type_counts {
-        debug!("Message type {:?} has {} messages", message_type, count);
-
-        if message_type == MessageType::RDADigitalRadarDataGenericFormat {
-            info!("{}", all_scans.join(", "));
-        }
-    }
-}
-
-struct ScanData {
-    start_azimuth: f32,
-    end_azimuth: f32,
-    elevation: u8,
-    data_types: std::collections::HashMap<String, usize>,
-}
-
-impl std::fmt::Display for ScanData {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "ScanData {{ azimuth: {:.0}-{:.0}, elevation: {}, data_types: {:?} }}",
-            self.start_azimuth, self.end_azimuth, self.elevation, self.data_types
-        )
-    }
 }

--- a/nexrad-data/examples/archive.rs
+++ b/nexrad-data/examples/archive.rs
@@ -3,7 +3,7 @@ use log::{debug, info, trace, LevelFilter};
 
 #[cfg(not(all(feature = "aws", feature = "decode")))]
 fn main() {
-    println!("This example requires the \"aws\" feature to be enabled.");
+    println!("This example requires the \"aws\" and \"decode\" features to be enabled.");
 }
 
 #[derive(Parser)]

--- a/nexrad-data/examples/realtime.rs
+++ b/nexrad-data/examples/realtime.rs
@@ -3,7 +3,7 @@ use log::{debug, info, trace, LevelFilter};
 
 #[cfg(not(all(feature = "aws", feature = "decode")))]
 fn main() {
-    println!("This example requires the \"aws\" feature to be enabled.");
+    println!("This example requires the \"aws\" and \"decode\" features to be enabled.");
 }
 
 #[derive(Parser)]

--- a/nexrad-data/src/aws/archive/identifier.rs
+++ b/nexrad-data/src/aws/archive/identifier.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 
 /// Identifying metadata for a NEXRAD archive volume file.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Identifier(String);
 
 impl Identifier {

--- a/nexrad-data/src/aws/realtime/chunk.rs
+++ b/nexrad-data/src/aws/realtime/chunk.rs
@@ -4,6 +4,7 @@ use crate::volume;
 
 /// A chunk of real-time data within a volume. Chunks are ordered and when concatenated together
 /// form a complete volume of radar data. All chunks contain an LDM record with radar data messages.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Chunk<'a> {
     /// The start of a new volume. This chunk will begin with an Archive II volume header followed
     /// by a compressed LDM record.

--- a/nexrad-data/src/aws/realtime/chunk_identifier.rs
+++ b/nexrad-data/src/aws/realtime/chunk_identifier.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 
 /// Identifies a volume chunk within the real-time NEXRAD data bucket. These chunks are uploaded
 /// every few seconds and contain a portion of the radar data for a specific volume.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ChunkIdentifier {
     site: String,
     volume: VolumeIndex,
@@ -127,6 +127,7 @@ impl ChunkIdentifier {
 }
 
 /// Identifies where to find the next expected chunk.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum NextChunk {
     /// The next chunk is expected to be located in the same volume at this sequence. The
     /// [ChunkIdentifier::with_sequence] method can be used to create the next chunk's identifier

--- a/nexrad-data/src/aws/realtime/chunk_type.rs
+++ b/nexrad-data/src/aws/realtime/chunk_type.rs
@@ -1,5 +1,5 @@
 /// The position of this chunk within the volume.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum ChunkType {
     Start,
     Intermediate,

--- a/nexrad-data/src/aws/realtime/get_latest_volume.rs
+++ b/nexrad-data/src/aws/realtime/get_latest_volume.rs
@@ -28,6 +28,7 @@ pub async fn get_latest_volume(site: &str) -> crate::result::Result<LatestVolume
 }
 
 /// Represents the most recent volume index and the number of network calls made to find it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct LatestVolumeResult {
     /// The most recent volume index, if found.
     pub volume: Option<VolumeIndex>,

--- a/nexrad-data/src/aws/realtime/poll_stats.rs
+++ b/nexrad-data/src/aws/realtime/poll_stats.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 /// Statistics from the polling process.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PollStats {
     /// The number of network calls made to find the most recent volume.
     LatestVolumeCalls(usize),
@@ -12,7 +12,7 @@ pub enum PollStats {
 }
 
 /// Statistics for a new chunk.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct NewChunkStats {
     /// The number of network calls made to find a new chunk.
     pub calls: usize,

--- a/nexrad-data/src/aws/realtime/volume_index.rs
+++ b/nexrad-data/src/aws/realtime/volume_index.rs
@@ -1,6 +1,6 @@
 /// A volume's index in the AWS real-time NEXRAD bucket. These indexes are rotated-through as chunks
 /// are accumulated and finally combined into full volumes to be archived.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct VolumeIndex(usize);
 
 impl VolumeIndex {

--- a/nexrad-data/src/aws/s3/bucket_list_result.rs
+++ b/nexrad-data/src/aws/s3/bucket_list_result.rs
@@ -1,6 +1,7 @@
 use crate::aws::s3::bucket_object::BucketObject;
 
 /// The result of a list objects request.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BucketListResult {
     /// Whether the list of objects is truncated.
     pub truncated: bool,

--- a/nexrad-data/src/aws/s3/bucket_object.rs
+++ b/nexrad-data/src/aws/s3/bucket_object.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 
 /// A bucket object returned from an S3 list objects request.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BucketObject {
     /// The key of the object.
     pub key: String,

--- a/nexrad-data/src/aws/s3/bucket_object_field.rs
+++ b/nexrad-data/src/aws/s3/bucket_object_field.rs
@@ -1,5 +1,5 @@
 /// A field in the S3 list objects response. These are not necessarily part of the same object.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BucketObjectField {
     /// Whether the list of objects is truncated. Child of `ListBucketResult`.
     IsTruncated,

--- a/nexrad-data/src/aws/s3/downloaded_bucket_object.rs
+++ b/nexrad-data/src/aws/s3/downloaded_bucket_object.rs
@@ -1,6 +1,7 @@
 use crate::aws::s3::bucket_object::BucketObject;
 
 /// A bucket object returned from an S3 list objects request.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DownloadedBucketObject {
     /// The metadata of the object.
     pub metadata: BucketObject,

--- a/nexrad-data/src/volume/file.rs
+++ b/nexrad-data/src/volume/file.rs
@@ -2,6 +2,7 @@ use crate::result::Result;
 use crate::volume::{split_compressed_records, Header, Record};
 
 /// A NEXRAD Archive II volume data file.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct File(Vec<u8>);
 
 impl File {

--- a/nexrad-data/src/volume/file.rs
+++ b/nexrad-data/src/volume/file.rs
@@ -1,8 +1,9 @@
 use crate::result::Result;
 use crate::volume::{split_compressed_records, Header, Record};
+use std::fmt::Debug;
 
 /// A NEXRAD Archive II volume data file.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct File(Vec<u8>);
 
 impl File {
@@ -61,5 +62,20 @@ impl File {
             coverage_pattern_number.ok_or(Error::MissingCoveragePattern)?,
             Sweep::from_radials(radials),
         ))
+    }
+}
+
+impl Debug for File {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("File");
+        debug.field("data.len()", &self.data().len());
+
+        #[cfg(all(feature = "serde", feature = "bincode"))]
+        debug.field("header", &self.header());
+
+        #[cfg(all(feature = "nexrad-model", feature = "decode"))]
+        debug.field("records.len()", &self.records().len());
+
+        debug.finish()
     }
 }

--- a/nexrad-data/src/volume/file.rs
+++ b/nexrad-data/src/volume/file.rs
@@ -29,7 +29,7 @@ impl File {
 
     /// Decodes this volume file into a common model scan containing sweeps and radials with moment
     /// data.
-    #[cfg(all(feature = "nexrad-model", feature = "decode", feature = "bzip2"))]
+    #[cfg(all(feature = "nexrad-model", feature = "decode"))]
     pub fn scan(&self) -> Result<nexrad_model::data::Scan> {
         use crate::result::Error;
         use nexrad_decode::messages::Message;

--- a/nexrad-data/src/volume/file.rs
+++ b/nexrad-data/src/volume/file.rs
@@ -2,7 +2,6 @@ use crate::result::Result;
 use crate::volume::{split_compressed_records, Header, Record};
 
 /// A NEXRAD Archive II volume data file.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct File(Vec<u8>);
 
 impl File {

--- a/nexrad-data/src/volume/header.rs
+++ b/nexrad-data/src/volume/header.rs
@@ -1,13 +1,13 @@
 use crate::result::Result;
 use crate::volume::util::get_datetime;
 use chrono::{DateTime, Duration, Utc};
-use std::fmt;
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 use std::io::Read;
 
 /// Header for an Archive II volume file containing metadata about the radar data. This header is
 /// located at the beginning of the file.
 #[repr(C)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct Header {
     /// The tape's filename which indicates the version of the data. Name is in the format
@@ -78,16 +78,5 @@ impl Header {
     /// The ICAO identifier of the radar site.
     pub fn icao_of_radar(&self) -> Option<String> {
         String::from_utf8(self.icao_of_radar.to_vec()).ok()
-    }
-}
-
-impl Debug for Header {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Header")
-            .field("tape_filename", &self.tape_filename())
-            .field("extension_number", &self.extension_number())
-            .field("date_time", &self.date_time())
-            .field("icao_of_radar", &self.icao_of_radar())
-            .finish()
     }
 }

--- a/nexrad-data/src/volume/header.rs
+++ b/nexrad-data/src/volume/header.rs
@@ -8,6 +8,7 @@ use std::io::Read;
 /// Header for an Archive II volume file containing metadata about the radar data. This header is
 /// located at the beginning of the file.
 #[repr(C)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct Header {
     /// The tape's filename which indicates the version of the data. Name is in the format

--- a/nexrad-data/src/volume/header.rs
+++ b/nexrad-data/src/volume/header.rs
@@ -1,13 +1,13 @@
 use crate::result::Result;
 use crate::volume::util::get_datetime;
 use chrono::{DateTime, Duration, Utc};
-use std::fmt::Debug;
+use std::fmt;
+use std::fmt::{Debug, Formatter};
 use std::io::Read;
 
 /// Header for an Archive II volume file containing metadata about the radar data. This header is
 /// located at the beginning of the file.
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct Header {
     /// The tape's filename which indicates the version of the data. Name is in the format
@@ -78,5 +78,16 @@ impl Header {
     /// The ICAO identifier of the radar site.
     pub fn icao_of_radar(&self) -> Option<String> {
         String::from_utf8(self.icao_of_radar.to_vec()).ok()
+    }
+}
+
+impl Debug for Header {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Header")
+            .field("tape_filename", &self.tape_filename())
+            .field("extension_number", &self.extension_number())
+            .field("date_time", &self.date_time())
+            .field("icao_of_radar", &self.icao_of_radar())
+            .finish()
     }
 }

--- a/nexrad-data/src/volume/record.rs
+++ b/nexrad-data/src/volume/record.rs
@@ -1,4 +1,3 @@
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum RecordData<'a> {
     Borrowed(&'a [u8]),
     Owned(Vec<u8>),
@@ -10,7 +9,6 @@ enum RecordData<'a> {
 /// NEXRAD archival radar data. A NEXRAD "Archive II" file starts with an
 /// [crate::volume::Header] followed by a series of compressed LDM records, each
 /// containing messages with radar data.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Record<'a>(RecordData<'a>);
 
 impl<'a> Record<'a> {

--- a/nexrad-data/src/volume/record.rs
+++ b/nexrad-data/src/volume/record.rs
@@ -1,3 +1,4 @@
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum RecordData<'a> {
     Borrowed(&'a [u8]),
     Owned(Vec<u8>),
@@ -9,6 +10,7 @@ enum RecordData<'a> {
 /// NEXRAD archival radar data. A NEXRAD "Archive II" file starts with an
 /// [crate::volume::Header] followed by a series of compressed LDM records, each
 /// containing messages with radar data.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Record<'a>(RecordData<'a>);
 
 impl<'a> Record<'a> {

--- a/nexrad-decode/src/lib.rs
+++ b/nexrad-decode/src/lib.rs
@@ -16,5 +16,6 @@
 
 pub mod messages;
 pub mod result;
+pub mod summarize;
 
 mod util;

--- a/nexrad-decode/src/messages/clutter_filter_map/azimuth_segment.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/azimuth_segment.rs
@@ -3,14 +3,14 @@ use crate::messages::primitive_aliases::Integer2;
 use serde::Deserialize;
 
 /// Header information for an azimuth segment to be read directly from the Archive II file.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
 pub struct AzimuthSegmentHeader {
     /// The number of range zones defined in this azimuth segment, from 1 to 20.
     pub range_zone_count: Integer2,
 }
 
 /// A segment of the clutter filter map for a specific elevation and azimuth containing range zones.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AzimuthSegment {
     /// Header information for this azimuth segment. This is the portion of an azimuth segment that
     /// is read directly from the Archive II file.

--- a/nexrad-decode/src/messages/clutter_filter_map/azimuth_segment.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/azimuth_segment.rs
@@ -3,14 +3,14 @@ use crate::messages::primitive_aliases::Integer2;
 use serde::Deserialize;
 
 /// Header information for an azimuth segment to be read directly from the Archive II file.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct AzimuthSegmentHeader {
     /// The number of range zones defined in this azimuth segment, from 1 to 20.
     pub range_zone_count: Integer2,
 }
 
 /// A segment of the clutter filter map for a specific elevation and azimuth containing range zones.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug)]
 pub struct AzimuthSegment {
     /// Header information for this azimuth segment. This is the portion of an azimuth segment that
     /// is read directly from the Archive II file.

--- a/nexrad-decode/src/messages/clutter_filter_map/definitions.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/definitions.rs
@@ -1,4 +1,5 @@
 /// Control codes indicating behavior of the clutter filter map for a range segment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum OpCode {
     /// The clutter filter is bypassed for the range segment.
     BypassFilter,

--- a/nexrad-decode/src/messages/clutter_filter_map/elevation_segment.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/elevation_segment.rs
@@ -2,7 +2,7 @@ use crate::messages::clutter_filter_map::azimuth_segment::AzimuthSegment;
 use crate::messages::primitive_aliases::Integer1;
 
 /// A segment of the clutter filter map for a specific elevation containing azimuth segments.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ElevationSegment {
     /// This elevation segment's number from 1 to 5 (oftentimes there are only 2) in increasing
     /// elevation from the ground.

--- a/nexrad-decode/src/messages/clutter_filter_map/elevation_segment.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/elevation_segment.rs
@@ -2,7 +2,7 @@ use crate::messages::clutter_filter_map::azimuth_segment::AzimuthSegment;
 use crate::messages::primitive_aliases::Integer1;
 
 /// A segment of the clutter filter map for a specific elevation containing azimuth segments.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug)]
 pub struct ElevationSegment {
     /// This elevation segment's number from 1 to 5 (oftentimes there are only 2) in increasing
     /// elevation from the ground.

--- a/nexrad-decode/src/messages/clutter_filter_map/header.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/header.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 /// Header information for a clutter filter map to be read directly from the Archive II file.
-#[derive(Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
 pub struct Header {
     /// The date the clutter filter map was generated represented as a count of days since 1 January
     /// 1970 00:00 GMT. It is also referred-to as a "modified Julian date" where it is the Julian
@@ -27,14 +27,5 @@ impl Header {
             self.map_generation_date,
             Duration::minutes(self.map_generation_time as i64),
         )
-    }
-}
-
-impl Debug for Header {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Header")
-            .field("map_generation_date_time", &self.date_time())
-            .field("elevation_segment_count", &self.elevation_segment_count)
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/clutter_filter_map/header.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/header.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 /// Header information for a clutter filter map to be read directly from the Archive II file.
-#[derive(Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Deserialize)]
 pub struct Header {
     /// The date the clutter filter map was generated represented as a count of days since 1 January
     /// 1970 00:00 GMT. It is also referred-to as a "modified Julian date" where it is the Julian

--- a/nexrad-decode/src/messages/clutter_filter_map/header.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/header.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 /// Header information for a clutter filter map to be read directly from the Archive II file.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[derive(Deserialize)]
 pub struct Header {
     /// The date the clutter filter map was generated represented as a count of days since 1 January
     /// 1970 00:00 GMT. It is also referred-to as a "modified Julian date" where it is the Julian
@@ -27,5 +27,14 @@ impl Header {
             self.map_generation_date,
             Duration::minutes(self.map_generation_time as i64),
         )
+    }
+}
+
+impl Debug for Header {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Header")
+            .field("map_generation_date_time", &self.date_time())
+            .field("elevation_segment_count", &self.elevation_segment_count)
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/clutter_filter_map/message.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/message.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 /// A clutter filter map describing elevations, azimuths, and ranges containing clutter to
 /// filtered from radar products.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug)]
 pub struct Message {
     /// Decoded header information for this clutter filter map.
     pub header: Header,

--- a/nexrad-decode/src/messages/clutter_filter_map/message.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/message.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 /// A clutter filter map describing elevations, azimuths, and ranges containing clutter to
 /// filtered from radar products.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Message {
     /// Decoded header information for this clutter filter map.
     pub header: Header,

--- a/nexrad-decode/src/messages/clutter_filter_map/range_zone.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/range_zone.rs
@@ -1,16 +1,14 @@
+use crate::messages::clutter_filter_map::OpCode;
 use crate::messages::primitive_aliases::{Code2, Integer2};
 use serde::Deserialize;
 use std::fmt::Debug;
 
-use crate::messages::clutter_filter_map::OpCode;
 #[cfg(feature = "uom")]
-use uom::si::f64::Length;
-#[cfg(feature = "uom")]
-use uom::si::length::kilometer;
+use uom::{si::f64::Length, si::length::kilometer};
 
 /// Defines a range segment of a particular elevation and azimuth with an operation type describing
 /// the clutter filter map behavior for the segment.
-#[derive(Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
 pub struct RangeZone {
     /// Operation code for the range zone.
     pub op_code: Code2,
@@ -36,25 +34,5 @@ impl RangeZone {
     #[cfg(feature = "uom")]
     pub fn end_range(&self) -> Length {
         Length::new::<kilometer>(self.end_range as f64)
-    }
-}
-
-#[cfg(not(feature = "uom"))]
-impl Debug for RangeZone {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RangeZone")
-            .field("op_code", &self.op_code)
-            .field("end_range", &self.end_range)
-            .finish()
-    }
-}
-
-#[cfg(feature = "uom")]
-impl Debug for RangeZone {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RangeZone")
-            .field("op_code", &self.op_code)
-            .field("end_range", &self.end_range())
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/clutter_filter_map/range_zone.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/range_zone.rs
@@ -10,7 +10,7 @@ use uom::si::length::kilometer;
 
 /// Defines a range segment of a particular elevation and azimuth with an operation type describing
 /// the clutter filter map behavior for the segment.
-#[derive(Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Deserialize)]
 pub struct RangeZone {
     /// Operation code for the range zone.
     pub op_code: Code2,

--- a/nexrad-decode/src/messages/clutter_filter_map/range_zone.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/range_zone.rs
@@ -1,14 +1,16 @@
-use crate::messages::clutter_filter_map::OpCode;
 use crate::messages::primitive_aliases::{Code2, Integer2};
 use serde::Deserialize;
 use std::fmt::Debug;
 
+use crate::messages::clutter_filter_map::OpCode;
 #[cfg(feature = "uom")]
-use uom::{si::f64::Length, si::length::kilometer};
+use uom::si::f64::Length;
+#[cfg(feature = "uom")]
+use uom::si::length::kilometer;
 
 /// Defines a range segment of a particular elevation and azimuth with an operation type describing
 /// the clutter filter map behavior for the segment.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[derive(Deserialize)]
 pub struct RangeZone {
     /// Operation code for the range zone.
     pub op_code: Code2,
@@ -34,5 +36,25 @@ impl RangeZone {
     #[cfg(feature = "uom")]
     pub fn end_range(&self) -> Length {
         Length::new::<kilometer>(self.end_range as f64)
+    }
+}
+
+#[cfg(not(feature = "uom"))]
+impl Debug for RangeZone {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RangeZone")
+            .field("op_code", &self.op_code)
+            .field("end_range", &self.end_range)
+            .finish()
+    }
+}
+
+#[cfg(feature = "uom")]
+impl Debug for RangeZone {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RangeZone")
+            .field("op_code", &self.op_code)
+            .field("end_range", &self.end_range())
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/definitions.rs
+++ b/nexrad-decode/src/messages/definitions.rs
@@ -1,5 +1,5 @@
 /// The possible RDA redundant channels.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum RedundantChannel {
     LegacySingleChannel,
     LegacyRedundantChannel1,

--- a/nexrad-decode/src/messages/digital_radar_data/data_block_id.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/data_block_id.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 /// A digital radar data block's identifier.
-#[derive(Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
 pub struct DataBlockId {
     /// Data block type, e.g. "R".
     pub data_block_type: u8,
@@ -20,14 +20,5 @@ impl DataBlockId {
     /// Data block name, e.g. "VOL".
     pub fn data_block_name(&self) -> String {
         String::from_utf8_lossy(&self.data_name).to_string()
-    }
-}
-
-impl Debug for DataBlockId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DataBlockId")
-            .field("data_block_type", &self.data_block_type())
-            .field("data_block_name", &self.data_block_name())
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/data_block_id.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/data_block_id.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 /// A digital radar data block's identifier.
-#[derive(Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Deserialize)]
 pub struct DataBlockId {
     /// Data block type, e.g. "R".
     pub data_block_type: u8,

--- a/nexrad-decode/src/messages/digital_radar_data/data_block_id.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/data_block_id.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 /// A digital radar data block's identifier.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[derive(Deserialize)]
 pub struct DataBlockId {
     /// Data block type, e.g. "R".
     pub data_block_type: u8,
@@ -20,5 +20,14 @@ impl DataBlockId {
     /// Data block name, e.g. "VOL".
     pub fn data_block_name(&self) -> String {
         String::from_utf8_lossy(&self.data_name).to_string()
+    }
+}
+
+impl Debug for DataBlockId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DataBlockId")
+            .field("data_block_type", &self.data_block_type())
+            .field("data_block_name", &self.data_block_name())
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/definitions.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/definitions.rs
@@ -1,5 +1,5 @@
 /// Indicates whether the message is compressed and what type of compression was used.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum CompressionIndicator {
     Uncompressed,
     CompressedBZIP2,
@@ -8,7 +8,7 @@ pub enum CompressionIndicator {
 }
 
 /// Possible statuses for a radial describing its position within the larger scan.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum RadialStatus {
     ElevationStart,
     IntermediateRadialData,
@@ -20,7 +20,7 @@ pub enum RadialStatus {
 }
 
 /// Flags indicating special control features.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum ControlFlags {
     None,
     RecombinedAzimuthalRadials,
@@ -29,7 +29,7 @@ pub enum ControlFlags {
 }
 
 /// Processing status flags.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ProcessingStatus {
     RxRNoise,
     CBT,
@@ -37,7 +37,7 @@ pub enum ProcessingStatus {
 }
 
 /// Volume coverage pattern (VCP) definitions.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum VolumeCoveragePattern {
     VCP12,
     VCP31,
@@ -49,6 +49,7 @@ pub enum VolumeCoveragePattern {
 
 /// The value for a data moment/radial, gate, and product. The value may be a floating-point number
 /// or a special case such as "below threshold" or "range folded".
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ScaledMomentValue {
     /// The converted floating-point representation of the data moment value for a gate.
     Value(f32),

--- a/nexrad-decode/src/messages/digital_radar_data/elevation_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/elevation_data_block.rs
@@ -4,12 +4,10 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 #[cfg(feature = "uom")]
-use uom::si::f64::Information;
-#[cfg(feature = "uom")]
-use uom::si::information::byte;
+use uom::{si::f64::Information, si::information::byte};
 
 /// An elevation data block.
-#[derive(Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct ElevationDataBlock {
     /// Data block identifier.
     pub data_block_id: DataBlockId,
@@ -30,29 +28,5 @@ impl ElevationDataBlock {
     #[cfg(feature = "uom")]
     pub fn lrtup(&self) -> Information {
         Information::new::<byte>(self.lrtup as f64)
-    }
-}
-
-#[cfg(not(feature = "uom"))]
-impl Debug for ElevationDataBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ElevationDataBlock")
-            .field("data_block_id", &self.data_block_id)
-            .field("lrtup", &self.lrtup)
-            .field("atmos", &self.atmos)
-            .field("calibration_constant", &self.calibration_constant)
-            .finish()
-    }
-}
-
-#[cfg(feature = "uom")]
-impl Debug for ElevationDataBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ElevationDataBlock")
-            .field("data_block_id", &self.data_block_id)
-            .field("lrtup", &self.lrtup())
-            .field("atmos", &self.atmos)
-            .field("calibration_constant", &self.calibration_constant)
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/elevation_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/elevation_data_block.rs
@@ -4,10 +4,12 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 #[cfg(feature = "uom")]
-use uom::{si::f64::Information, si::information::byte};
+use uom::si::f64::Information;
+#[cfg(feature = "uom")]
+use uom::si::information::byte;
 
 /// An elevation data block.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Deserialize)]
 pub struct ElevationDataBlock {
     /// Data block identifier.
     pub data_block_id: DataBlockId,
@@ -28,5 +30,29 @@ impl ElevationDataBlock {
     #[cfg(feature = "uom")]
     pub fn lrtup(&self) -> Information {
         Information::new::<byte>(self.lrtup as f64)
+    }
+}
+
+#[cfg(not(feature = "uom"))]
+impl Debug for ElevationDataBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ElevationDataBlock")
+            .field("data_block_id", &self.data_block_id)
+            .field("lrtup", &self.lrtup)
+            .field("atmos", &self.atmos)
+            .field("calibration_constant", &self.calibration_constant)
+            .finish()
+    }
+}
+
+#[cfg(feature = "uom")]
+impl Debug for ElevationDataBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ElevationDataBlock")
+            .field("data_block_id", &self.data_block_id)
+            .field("lrtup", &self.lrtup())
+            .field("atmos", &self.atmos)
+            .field("calibration_constant", &self.calibration_constant)
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/elevation_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/elevation_data_block.rs
@@ -9,7 +9,7 @@ use uom::si::f64::Information;
 use uom::si::information::byte;
 
 /// An elevation data block.
-#[derive(Deserialize)]
+#[derive(Clone, PartialEq, Deserialize)]
 pub struct ElevationDataBlock {
     /// Data block identifier.
     pub data_block_id: DataBlockId,

--- a/nexrad-decode/src/messages/digital_radar_data/generic_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/generic_data_block.rs
@@ -6,14 +6,13 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 #[cfg(feature = "uom")]
-use uom::{
-    si::f64::{Information, Length},
-    si::information::byte,
-    si::length::kilometer,
-};
+use uom::si::f64::{Information, Length};
+#[cfg(feature = "uom")]
+use uom::si::information::byte;
+#[cfg(feature = "uom")]
+use uom::si::length::kilometer;
 
 /// A generic data moment block.
-#[derive(Debug, Clone, PartialEq)]
 pub struct GenericDataBlock {
     /// The generic data block's header information.
     pub header: GenericDataBlockHeader,
@@ -84,8 +83,17 @@ impl GenericDataBlock {
     }
 }
 
+impl Debug for GenericDataBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GenericDataBlock")
+            .field("header", &self.header)
+            .field("data", &self.encoded_data.len())
+            .finish()
+    }
+}
+
 /// A generic data moment block's decoded header.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Deserialize)]
 pub struct GenericDataBlockHeader {
     /// Data block identifier.
     pub data_block_id: DataBlockId,
@@ -158,5 +166,55 @@ impl GenericDataBlockHeader {
         Information::new::<byte>(
             self.number_of_data_moment_gates as f64 * self.data_word_size as f64 / 8.0,
         )
+    }
+}
+
+#[cfg(not(feature = "uom"))]
+impl Debug for GenericDataBlockHeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GenericDataBlockHeader")
+            .field("data_block_id", &self.data_block_id)
+            .field("reserved", &self.reserved)
+            .field(
+                "number_of_data_moment_gates",
+                &self.number_of_data_moment_gates,
+            )
+            .field("data_moment_range", &self.data_moment_range)
+            .field(
+                "data_moment_range_sample_interval",
+                &self.data_moment_range_sample_interval,
+            )
+            .field("tover", &self.tover)
+            .field("snr_threshold", &self.snr_threshold)
+            .field("control_flags", &self.control_flags())
+            .field("data_word_size", &self.data_word_size)
+            .field("scale", &self.scale)
+            .field("offset", &self.offset)
+            .finish()
+    }
+}
+
+#[cfg(feature = "uom")]
+impl Debug for GenericDataBlockHeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GenericDataBlockHeader")
+            .field("data_block_id", &self.data_block_id)
+            .field("reserved", &self.reserved)
+            .field(
+                "number_of_data_moment_gates",
+                &self.number_of_data_moment_gates,
+            )
+            .field("data_moment_range", &self.data_moment_range())
+            .field(
+                "data_moment_range_sample_interval",
+                &self.data_moment_range_sample_interval(),
+            )
+            .field("tover", &self.tover)
+            .field("snr_threshold", &self.snr_threshold)
+            .field("control_flags", &self.control_flags())
+            .field("data_word_size", &self.data_word_size)
+            .field("scale", &self.scale)
+            .field("offset", &self.offset)
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/generic_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/generic_data_block.rs
@@ -13,6 +13,7 @@ use uom::si::information::byte;
 use uom::si::length::kilometer;
 
 /// A generic data moment block.
+#[derive(Clone, PartialEq)]
 pub struct GenericDataBlock {
     /// The generic data block's header information.
     pub header: GenericDataBlockHeader,
@@ -93,7 +94,7 @@ impl Debug for GenericDataBlock {
 }
 
 /// A generic data moment block's decoded header.
-#[derive(Deserialize)]
+#[derive(Clone, PartialEq, Deserialize)]
 pub struct GenericDataBlockHeader {
     /// Data block identifier.
     pub data_block_id: DataBlockId,

--- a/nexrad-decode/src/messages/digital_radar_data/generic_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/generic_data_block.rs
@@ -6,13 +6,14 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 #[cfg(feature = "uom")]
-use uom::si::f64::{Information, Length};
-#[cfg(feature = "uom")]
-use uom::si::information::byte;
-#[cfg(feature = "uom")]
-use uom::si::length::kilometer;
+use uom::{
+    si::f64::{Information, Length},
+    si::information::byte,
+    si::length::kilometer,
+};
 
 /// A generic data moment block.
+#[derive(Debug, Clone, PartialEq)]
 pub struct GenericDataBlock {
     /// The generic data block's header information.
     pub header: GenericDataBlockHeader,
@@ -83,17 +84,8 @@ impl GenericDataBlock {
     }
 }
 
-impl Debug for GenericDataBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GenericDataBlock")
-            .field("header", &self.header)
-            .field("data", &self.encoded_data.len())
-            .finish()
-    }
-}
-
 /// A generic data moment block's decoded header.
-#[derive(Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct GenericDataBlockHeader {
     /// Data block identifier.
     pub data_block_id: DataBlockId,
@@ -166,55 +158,5 @@ impl GenericDataBlockHeader {
         Information::new::<byte>(
             self.number_of_data_moment_gates as f64 * self.data_word_size as f64 / 8.0,
         )
-    }
-}
-
-#[cfg(not(feature = "uom"))]
-impl Debug for GenericDataBlockHeader {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GenericDataBlockHeader")
-            .field("data_block_id", &self.data_block_id)
-            .field("reserved", &self.reserved)
-            .field(
-                "number_of_data_moment_gates",
-                &self.number_of_data_moment_gates,
-            )
-            .field("data_moment_range", &self.data_moment_range)
-            .field(
-                "data_moment_range_sample_interval",
-                &self.data_moment_range_sample_interval,
-            )
-            .field("tover", &self.tover)
-            .field("snr_threshold", &self.snr_threshold)
-            .field("control_flags", &self.control_flags())
-            .field("data_word_size", &self.data_word_size)
-            .field("scale", &self.scale)
-            .field("offset", &self.offset)
-            .finish()
-    }
-}
-
-#[cfg(feature = "uom")]
-impl Debug for GenericDataBlockHeader {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GenericDataBlockHeader")
-            .field("data_block_id", &self.data_block_id)
-            .field("reserved", &self.reserved)
-            .field(
-                "number_of_data_moment_gates",
-                &self.number_of_data_moment_gates,
-            )
-            .field("data_moment_range", &self.data_moment_range())
-            .field(
-                "data_moment_range_sample_interval",
-                &self.data_moment_range_sample_interval(),
-            )
-            .field("tover", &self.tover)
-            .field("snr_threshold", &self.snr_threshold)
-            .field("control_flags", &self.control_flags())
-            .field("data_word_size", &self.data_word_size)
-            .field("scale", &self.scale)
-            .field("offset", &self.offset)
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/header.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/header.rs
@@ -9,15 +9,15 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 #[cfg(feature = "uom")]
-use uom::{
-    si::angle::degree,
-    si::f64::{Angle, Information},
-    si::information::byte,
-};
+use uom::si::angle::degree;
+#[cfg(feature = "uom")]
+use uom::si::f64::{Angle, Information};
+#[cfg(feature = "uom")]
+use uom::si::information::byte;
 
 /// The digital radar data message header block precedes base data information for a particular
 /// radial and includes parameters for that radial and information about the following data blocks.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Deserialize)]
 pub struct Header {
     /// ICAO radar identifier.
     pub radar_identifier: [u8; 4],
@@ -174,5 +174,61 @@ impl Header {
                 self.azimuth_indexing_mode as f64 * 0.01,
             ))
         }
+    }
+}
+
+#[cfg(not(feature = "uom"))]
+impl Debug for Header {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Header")
+            .field("radar_identifier", &self.radar_identifier())
+            .field("date_time", &self.date_time())
+            .field("azimuth_number", &self.azimuth_number)
+            .field("azimuth_angle", &self.azimuth_angle)
+            .field("compression_indicator", &self.compression_indicator())
+            .field("radial_length", &self.radial_length)
+            .field(
+                "azimuth_resolution_spacing",
+                &self.azimuth_resolution_spacing,
+            )
+            .field("radial_status", &self.radial_status())
+            .field("elevation_number", &self.elevation_number)
+            .field("cut_sector_number", &self.cut_sector_number)
+            .field("elevation_angle", &self.elevation_angle)
+            .field(
+                "radial_spot_blanking_status",
+                &self.radial_spot_blanking_status(),
+            )
+            .field("azimuth_indexing_mode", &self.azimuth_indexing_mode)
+            .field("data_block_count", &self.data_block_count)
+            .finish()
+    }
+}
+
+#[cfg(feature = "uom")]
+impl Debug for Header {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Header")
+            .field("radar_identifier", &self.radar_identifier())
+            .field("date_time", &self.date_time())
+            .field("azimuth_number", &self.azimuth_number)
+            .field("azimuth_angle", &self.azimuth_angle())
+            .field("compression_indicator", &self.compression_indicator())
+            .field("radial_length", &self.radial_length())
+            .field(
+                "azimuth_resolution_spacing",
+                &self.azimuth_resolution_spacing(),
+            )
+            .field("radial_status", &self.radial_status())
+            .field("elevation_number", &self.elevation_number)
+            .field("cut_sector_number", &self.cut_sector_number)
+            .field("elevation_angle", &self.elevation_angle())
+            .field(
+                "radial_spot_blanking_status",
+                &self.radial_spot_blanking_status(),
+            )
+            .field("azimuth_indexing_mode", &self.azimuth_indexing_mode())
+            .field("data_block_count", &self.data_block_count)
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/header.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/header.rs
@@ -17,7 +17,7 @@ use uom::si::information::byte;
 
 /// The digital radar data message header block precedes base data information for a particular
 /// radial and includes parameters for that radial and information about the following data blocks.
-#[derive(Deserialize)]
+#[derive(Clone, PartialEq, Deserialize)]
 pub struct Header {
     /// ICAO radar identifier.
     pub radar_identifier: [u8; 4],

--- a/nexrad-decode/src/messages/digital_radar_data/header.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/header.rs
@@ -9,15 +9,15 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 #[cfg(feature = "uom")]
-use uom::si::angle::degree;
-#[cfg(feature = "uom")]
-use uom::si::f64::{Angle, Information};
-#[cfg(feature = "uom")]
-use uom::si::information::byte;
+use uom::{
+    si::angle::degree,
+    si::f64::{Angle, Information},
+    si::information::byte,
+};
 
 /// The digital radar data message header block precedes base data information for a particular
 /// radial and includes parameters for that radial and information about the following data blocks.
-#[derive(Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct Header {
     /// ICAO radar identifier.
     pub radar_identifier: [u8; 4],
@@ -174,61 +174,5 @@ impl Header {
                 self.azimuth_indexing_mode as f64 * 0.01,
             ))
         }
-    }
-}
-
-#[cfg(not(feature = "uom"))]
-impl Debug for Header {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Header")
-            .field("radar_identifier", &self.radar_identifier())
-            .field("date_time", &self.date_time())
-            .field("azimuth_number", &self.azimuth_number)
-            .field("azimuth_angle", &self.azimuth_angle)
-            .field("compression_indicator", &self.compression_indicator())
-            .field("radial_length", &self.radial_length)
-            .field(
-                "azimuth_resolution_spacing",
-                &self.azimuth_resolution_spacing,
-            )
-            .field("radial_status", &self.radial_status())
-            .field("elevation_number", &self.elevation_number)
-            .field("cut_sector_number", &self.cut_sector_number)
-            .field("elevation_angle", &self.elevation_angle)
-            .field(
-                "radial_spot_blanking_status",
-                &self.radial_spot_blanking_status(),
-            )
-            .field("azimuth_indexing_mode", &self.azimuth_indexing_mode)
-            .field("data_block_count", &self.data_block_count)
-            .finish()
-    }
-}
-
-#[cfg(feature = "uom")]
-impl Debug for Header {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Header")
-            .field("radar_identifier", &self.radar_identifier())
-            .field("date_time", &self.date_time())
-            .field("azimuth_number", &self.azimuth_number)
-            .field("azimuth_angle", &self.azimuth_angle())
-            .field("compression_indicator", &self.compression_indicator())
-            .field("radial_length", &self.radial_length())
-            .field(
-                "azimuth_resolution_spacing",
-                &self.azimuth_resolution_spacing(),
-            )
-            .field("radial_status", &self.radial_status())
-            .field("elevation_number", &self.elevation_number)
-            .field("cut_sector_number", &self.cut_sector_number)
-            .field("elevation_angle", &self.elevation_angle())
-            .field(
-                "radial_spot_blanking_status",
-                &self.radial_spot_blanking_status(),
-            )
-            .field("azimuth_indexing_mode", &self.azimuth_indexing_mode())
-            .field("data_block_count", &self.data_block_count)
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/message.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/message.rs
@@ -4,7 +4,7 @@ use crate::messages::digital_radar_data::{
 
 /// The digital radar data message includes base radar data from a single radial for various
 /// products.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Message {
     /// The decoded digital radar data header.
     pub header: Header,

--- a/nexrad-decode/src/messages/digital_radar_data/message.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/message.rs
@@ -4,7 +4,7 @@ use crate::messages::digital_radar_data::{
 
 /// The digital radar data message includes base radar data from a single radial for various
 /// products.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug)]
 pub struct Message {
     /// The decoded digital radar data header.
     pub header: Header,

--- a/nexrad-decode/src/messages/digital_radar_data/pointers.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/pointers.rs
@@ -10,7 +10,7 @@ pub struct DataMomentPointer {
 }
 
 /// The type of data moment that the pointer references.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum DataMomentPointerType {
     Volume,
     Elevation,
@@ -19,7 +19,7 @@ pub enum DataMomentPointerType {
 }
 
 /// The type of generic data moment that the pointer references.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum DataMomentGenericPointerType {
     Reflectivity,
     Velocity,

--- a/nexrad-decode/src/messages/digital_radar_data/radial_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/radial_data_block.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use uom::si::f64::{Information, Length, Velocity};
 
 /// A radial data moment block.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Deserialize)]
 pub struct RadialDataBlock {
     /// Data block identifier.
     pub data_block_id: DataBlockId,
@@ -54,5 +54,63 @@ impl RadialDataBlock {
     #[cfg(feature = "uom")]
     pub fn nyquist_velocity(&self) -> Velocity {
         Velocity::new::<uom::si::velocity::meter_per_second>(self.nyquist_velocity as f64)
+    }
+}
+
+#[cfg(not(feature = "uom"))]
+impl Debug for RadialDataBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RadialDataBlock")
+            .field("data_block_id", &self.data_block_id)
+            .field("lrtup", &self.lrtup)
+            .field("unambiguous_range", &self.unambiguous_range)
+            .field(
+                "horizontal_channel_noise_level",
+                &self.horizontal_channel_noise_level,
+            )
+            .field(
+                "vertical_channel_noise_level",
+                &self.vertical_channel_noise_level,
+            )
+            .field("nyquist_velocity", &self.nyquist_velocity)
+            .field("radial_flags", &self.radial_flags)
+            .field(
+                "horizontal_channel_calibration_constant",
+                &self.horizontal_channel_calibration_constant,
+            )
+            .field(
+                "vertical_channel_calibration_constant",
+                &self.vertical_channel_calibration_constant,
+            )
+            .finish()
+    }
+}
+
+#[cfg(feature = "uom")]
+impl Debug for RadialDataBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RadialDataBlock")
+            .field("data_block_id", &self.data_block_id)
+            .field("lrtup", &self.lrtup())
+            .field("unambiguous_range", &self.unambiguous_range())
+            .field(
+                "horizontal_channel_noise_level",
+                &self.horizontal_channel_noise_level,
+            )
+            .field(
+                "vertical_channel_noise_level",
+                &self.vertical_channel_noise_level,
+            )
+            .field("nyquist_velocity", &self.nyquist_velocity())
+            .field("radial_flags", &self.radial_flags)
+            .field(
+                "horizontal_channel_calibration_constant",
+                &self.horizontal_channel_calibration_constant,
+            )
+            .field(
+                "vertical_channel_calibration_constant",
+                &self.vertical_channel_calibration_constant,
+            )
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/radial_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/radial_data_block.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use uom::si::f64::{Information, Length, Velocity};
 
 /// A radial data moment block.
-#[derive(Deserialize)]
+#[derive(Clone, PartialEq, Deserialize)]
 pub struct RadialDataBlock {
     /// Data block identifier.
     pub data_block_id: DataBlockId,

--- a/nexrad-decode/src/messages/digital_radar_data/radial_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/radial_data_block.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use uom::si::f64::{Information, Length, Velocity};
 
 /// A radial data moment block.
-#[derive(Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct RadialDataBlock {
     /// Data block identifier.
     pub data_block_id: DataBlockId,
@@ -54,63 +54,5 @@ impl RadialDataBlock {
     #[cfg(feature = "uom")]
     pub fn nyquist_velocity(&self) -> Velocity {
         Velocity::new::<uom::si::velocity::meter_per_second>(self.nyquist_velocity as f64)
-    }
-}
-
-#[cfg(not(feature = "uom"))]
-impl Debug for RadialDataBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RadialDataBlock")
-            .field("data_block_id", &self.data_block_id)
-            .field("lrtup", &self.lrtup)
-            .field("unambiguous_range", &self.unambiguous_range)
-            .field(
-                "horizontal_channel_noise_level",
-                &self.horizontal_channel_noise_level,
-            )
-            .field(
-                "vertical_channel_noise_level",
-                &self.vertical_channel_noise_level,
-            )
-            .field("nyquist_velocity", &self.nyquist_velocity)
-            .field("radial_flags", &self.radial_flags)
-            .field(
-                "horizontal_channel_calibration_constant",
-                &self.horizontal_channel_calibration_constant,
-            )
-            .field(
-                "vertical_channel_calibration_constant",
-                &self.vertical_channel_calibration_constant,
-            )
-            .finish()
-    }
-}
-
-#[cfg(feature = "uom")]
-impl Debug for RadialDataBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RadialDataBlock")
-            .field("data_block_id", &self.data_block_id)
-            .field("lrtup", &self.lrtup())
-            .field("unambiguous_range", &self.unambiguous_range())
-            .field(
-                "horizontal_channel_noise_level",
-                &self.horizontal_channel_noise_level,
-            )
-            .field(
-                "vertical_channel_noise_level",
-                &self.vertical_channel_noise_level,
-            )
-            .field("nyquist_velocity", &self.nyquist_velocity())
-            .field("radial_flags", &self.radial_flags)
-            .field(
-                "horizontal_channel_calibration_constant",
-                &self.horizontal_channel_calibration_constant,
-            )
-            .field(
-                "vertical_channel_calibration_constant",
-                &self.vertical_channel_calibration_constant,
-            )
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/spot_blanking_status.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/spot_blanking_status.rs
@@ -1,7 +1,6 @@
 use crate::messages::primitive_aliases::Code1;
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SpotBlankingStatus(Code1);
 
 /// Statuses:
@@ -33,5 +32,16 @@ impl SpotBlankingStatus {
     /// Whether spot blanking is active for the volume.
     pub fn volume(&self) -> bool {
         self.0 & 0b0100 != 0
+    }
+}
+
+impl Debug for SpotBlankingStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpotBlankingStatus")
+            .field("none", &self.none())
+            .field("radial", &self.radial())
+            .field("elevation", &self.elevation())
+            .field("volume", &self.volume())
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/spot_blanking_status.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/spot_blanking_status.rs
@@ -1,6 +1,7 @@
 use crate::messages::primitive_aliases::Code1;
 use std::fmt::{Debug, Formatter};
 
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct SpotBlankingStatus(Code1);
 
 /// Statuses:

--- a/nexrad-decode/src/messages/digital_radar_data/spot_blanking_status.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/spot_blanking_status.rs
@@ -1,6 +1,7 @@
 use crate::messages::primitive_aliases::Code1;
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SpotBlankingStatus(Code1);
 
 /// Statuses:
@@ -32,16 +33,5 @@ impl SpotBlankingStatus {
     /// Whether spot blanking is active for the volume.
     pub fn volume(&self) -> bool {
         self.0 & 0b0100 != 0
-    }
-}
-
-impl Debug for SpotBlankingStatus {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SpotBlankingStatus")
-            .field("none", &self.none())
-            .field("radial", &self.radial())
-            .field("elevation", &self.elevation())
-            .field("volume", &self.volume())
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/volume_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/volume_data_block.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use uom::si::f64::{Angle, Energy, Information, Length};
 
 /// A volume data moment block.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Deserialize)]
 pub struct VolumeDataBlock {
     /// Data block identifier.
     pub data_block_id: DataBlockId,
@@ -138,5 +138,79 @@ impl VolumeDataBlock {
             1 => ProcessingStatus::CBT,
             _ => ProcessingStatus::Other(self.processing_status),
         }
+    }
+}
+
+#[cfg(not(feature = "uom"))]
+impl Debug for VolumeDataBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VolumeDataBlock")
+            .field("data_block_id", &self.data_block_id)
+            .field("lrtup", &self.lrtup)
+            .field("major_version_number", &self.major_version_number)
+            .field("minor_version_number", &self.minor_version_number)
+            .field("latitude", &self.latitude)
+            .field("longitude", &self.longitude)
+            .field("site_height", &self.site_height)
+            .field("feedhorn_height", &self.feedhorn_height)
+            .field("calibration_constant", &self.calibration_constant)
+            .field("horizontal_shv_tx_power", &self.horizontal_shv_tx_power)
+            .field("vertical_shv_tx_power", &self.vertical_shv_tx_power)
+            .field(
+                "system_differential_reflectivity",
+                &self.system_differential_reflectivity,
+            )
+            .field(
+                "initial_system_differential_phase",
+                &self.initial_system_differential_phase,
+            )
+            .field(
+                "volume_coverage_pattern_number",
+                &self.volume_coverage_pattern_number,
+            )
+            .field("processing_status", &self.processing_status())
+            .field(
+                "zdr_bias_estimate_weighted_mean",
+                &self.zdr_bias_estimate_weighted_mean,
+            )
+            .field("spare", &self.spare)
+            .finish()
+    }
+}
+
+#[cfg(feature = "uom")]
+impl Debug for VolumeDataBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VolumeDataBlock")
+            .field("data_block_id", &self.data_block_id)
+            .field("lrtup", &self.lrtup())
+            .field("major_version_number", &self.major_version_number)
+            .field("minor_version_number", &self.minor_version_number)
+            .field("latitude", &self.latitude())
+            .field("longitude", &self.longitude())
+            .field("site_height", &self.site_height())
+            .field("feedhorn_height", &self.feedhorn_height())
+            .field("calibration_constant", &self.calibration_constant)
+            .field("horizontal_shv_tx_power", &self.horizontal_shv_tx_power())
+            .field("vertical_shv_tx_power", &self.vertical_shv_tx_power())
+            .field(
+                "system_differential_reflectivity",
+                &self.system_differential_reflectivity,
+            )
+            .field(
+                "initial_system_differential_phase",
+                &self.initial_system_differential_phase(),
+            )
+            .field(
+                "volume_coverage_pattern_number",
+                &self.volume_coverage_pattern_number,
+            )
+            .field("processing_status", &self.processing_status())
+            .field(
+                "zdr_bias_estimate_weighted_mean",
+                &self.zdr_bias_estimate_weighted_mean,
+            )
+            .field("spare", &self.spare)
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/volume_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/volume_data_block.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use uom::si::f64::{Angle, Energy, Information, Length};
 
 /// A volume data moment block.
-#[derive(Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct VolumeDataBlock {
     /// Data block identifier.
     pub data_block_id: DataBlockId,
@@ -138,79 +138,5 @@ impl VolumeDataBlock {
             1 => ProcessingStatus::CBT,
             _ => ProcessingStatus::Other(self.processing_status),
         }
-    }
-}
-
-#[cfg(not(feature = "uom"))]
-impl Debug for VolumeDataBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VolumeDataBlock")
-            .field("data_block_id", &self.data_block_id)
-            .field("lrtup", &self.lrtup)
-            .field("major_version_number", &self.major_version_number)
-            .field("minor_version_number", &self.minor_version_number)
-            .field("latitude", &self.latitude)
-            .field("longitude", &self.longitude)
-            .field("site_height", &self.site_height)
-            .field("feedhorn_height", &self.feedhorn_height)
-            .field("calibration_constant", &self.calibration_constant)
-            .field("horizontal_shv_tx_power", &self.horizontal_shv_tx_power)
-            .field("vertical_shv_tx_power", &self.vertical_shv_tx_power)
-            .field(
-                "system_differential_reflectivity",
-                &self.system_differential_reflectivity,
-            )
-            .field(
-                "initial_system_differential_phase",
-                &self.initial_system_differential_phase,
-            )
-            .field(
-                "volume_coverage_pattern_number",
-                &self.volume_coverage_pattern_number,
-            )
-            .field("processing_status", &self.processing_status())
-            .field(
-                "zdr_bias_estimate_weighted_mean",
-                &self.zdr_bias_estimate_weighted_mean,
-            )
-            .field("spare", &self.spare)
-            .finish()
-    }
-}
-
-#[cfg(feature = "uom")]
-impl Debug for VolumeDataBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VolumeDataBlock")
-            .field("data_block_id", &self.data_block_id)
-            .field("lrtup", &self.lrtup())
-            .field("major_version_number", &self.major_version_number)
-            .field("minor_version_number", &self.minor_version_number)
-            .field("latitude", &self.latitude())
-            .field("longitude", &self.longitude())
-            .field("site_height", &self.site_height())
-            .field("feedhorn_height", &self.feedhorn_height())
-            .field("calibration_constant", &self.calibration_constant)
-            .field("horizontal_shv_tx_power", &self.horizontal_shv_tx_power())
-            .field("vertical_shv_tx_power", &self.vertical_shv_tx_power())
-            .field(
-                "system_differential_reflectivity",
-                &self.system_differential_reflectivity,
-            )
-            .field(
-                "initial_system_differential_phase",
-                &self.initial_system_differential_phase(),
-            )
-            .field(
-                "volume_coverage_pattern_number",
-                &self.volume_coverage_pattern_number,
-            )
-            .field("processing_status", &self.processing_status())
-            .field(
-                "zdr_bias_estimate_weighted_mean",
-                &self.zdr_bias_estimate_weighted_mean,
-            )
-            .field("spare", &self.spare)
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/digital_radar_data/volume_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/volume_data_block.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use uom::si::f64::{Angle, Energy, Information, Length};
 
 /// A volume data moment block.
-#[derive(Deserialize)]
+#[derive(Clone, PartialEq, Deserialize)]
 pub struct VolumeDataBlock {
     /// Data block identifier.
     pub data_block_id: DataBlockId,

--- a/nexrad-decode/src/messages/message.rs
+++ b/nexrad-decode/src/messages/message.rs
@@ -4,14 +4,14 @@ use crate::messages::message_header::MessageHeader;
 use crate::messages::rda_status_data;
 
 /// A decoded NEXRAD Level II message with its metadata header.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct MessageWithHeader {
     pub header: MessageHeader,
     pub message: Message,
 }
 
 /// A decoded NEXRAD Level II message.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Message {
     RDAStatusData(Box<rda_status_data::Message>),
     DigitalRadarData(Box<digital_radar_data::Message>),

--- a/nexrad-decode/src/messages/message.rs
+++ b/nexrad-decode/src/messages/message.rs
@@ -4,14 +4,14 @@ use crate::messages::message_header::MessageHeader;
 use crate::messages::rda_status_data;
 
 /// A decoded NEXRAD Level II message with its metadata header.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug)]
 pub struct MessageWithHeader {
     pub header: MessageHeader,
     pub message: Message,
 }
 
 /// A decoded NEXRAD Level II message.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug)]
 pub enum Message {
     RDAStatusData(Box<rda_status_data::Message>),
     DigitalRadarData(Box<digital_radar_data::Message>),

--- a/nexrad-decode/src/messages/message_header.rs
+++ b/nexrad-decode/src/messages/message_header.rs
@@ -21,7 +21,7 @@ pub const VARIABLE_LENGTH_MESSAGE_SIZE: u16 = 65535;
 /// instead variable-length, with the segment count and segment number positions of the header
 /// (bytes 12-15) specifying the size of the full message in bytes.
 #[repr(C)]
-#[derive(Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Deserialize)]
 pub struct MessageHeader {
     rpg_unknown: [u8; 12],
 

--- a/nexrad-decode/src/messages/message_header.rs
+++ b/nexrad-decode/src/messages/message_header.rs
@@ -21,7 +21,7 @@ pub const VARIABLE_LENGTH_MESSAGE_SIZE: u16 = 65535;
 /// instead variable-length, with the segment count and segment number positions of the header
 /// (bytes 12-15) specifying the size of the full message in bytes.
 #[repr(C)]
-#[derive(Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
 pub struct MessageHeader {
     rpg_unknown: [u8; 12],
 
@@ -194,37 +194,5 @@ impl MessageHeader {
                 Information::new::<byte>(message_size_bytes as f64)
             }
         }
-    }
-}
-
-#[cfg(not(feature = "uom"))]
-impl Debug for MessageHeader {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MessageHeader")
-            .field("segment_size", &self.segment_size)
-            .field("redundant_channel", &self.rda_redundant_channel())
-            .field("message_type", &self.message_type())
-            .field("sequence_number", &self.sequence_number)
-            .field("date_time", &self.date_time())
-            .field("segment_count", &self.segment_count())
-            .field("segment_number", &self.segment_number())
-            .field("message_size_bytes", &self.message_size_bytes())
-            .finish()
-    }
-}
-
-#[cfg(feature = "uom")]
-impl Debug for MessageHeader {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MessageHeader")
-            .field("segment_size", &self.segment_size())
-            .field("redundant_channel", &self.rda_redundant_channel())
-            .field("message_type", &self.message_type())
-            .field("sequence_number", &self.sequence_number)
-            .field("date_time", &self.date_time())
-            .field("segment_count", &self.segment_count())
-            .field("segment_number", &self.segment_number())
-            .field("message_size", &self.message_size())
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/message_header.rs
+++ b/nexrad-decode/src/messages/message_header.rs
@@ -21,7 +21,7 @@ pub const VARIABLE_LENGTH_MESSAGE_SIZE: u16 = 65535;
 /// instead variable-length, with the segment count and segment number positions of the header
 /// (bytes 12-15) specifying the size of the full message in bytes.
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[derive(Deserialize)]
 pub struct MessageHeader {
     rpg_unknown: [u8; 12],
 
@@ -194,5 +194,37 @@ impl MessageHeader {
                 Information::new::<byte>(message_size_bytes as f64)
             }
         }
+    }
+}
+
+#[cfg(not(feature = "uom"))]
+impl Debug for MessageHeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MessageHeader")
+            .field("segment_size", &self.segment_size)
+            .field("redundant_channel", &self.rda_redundant_channel())
+            .field("message_type", &self.message_type())
+            .field("sequence_number", &self.sequence_number)
+            .field("date_time", &self.date_time())
+            .field("segment_count", &self.segment_count())
+            .field("segment_number", &self.segment_number())
+            .field("message_size_bytes", &self.message_size_bytes())
+            .finish()
+    }
+}
+
+#[cfg(feature = "uom")]
+impl Debug for MessageHeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MessageHeader")
+            .field("segment_size", &self.segment_size())
+            .field("redundant_channel", &self.rda_redundant_channel())
+            .field("message_type", &self.message_type())
+            .field("sequence_number", &self.sequence_number)
+            .field("date_time", &self.date_time())
+            .field("segment_count", &self.segment_count())
+            .field("segment_number", &self.segment_number())
+            .field("message_size", &self.message_size())
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/rda_status_data/alarm/model.rs
+++ b/nexrad-decode/src/messages/rda_status_data/alarm/model.rs
@@ -1,5 +1,5 @@
 /// An RDA alarm message definition to be referenced by an RDA status data message.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Message {
     code: u16,
     state: Option<State>,
@@ -60,7 +60,7 @@ impl Message {
 }
 
 /// The status of the RDA as a result of the alarm.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum State {
     MaintenanceMandatory,
     MaintenanceRequired,
@@ -70,7 +70,7 @@ pub enum State {
 }
 
 /// The different classifications of alarms.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum AlarmType {
     /// Alarm failed consecutively enough times to meet the alarm reporting count/sample threshold.
     EdgeDetected,
@@ -81,7 +81,7 @@ pub enum AlarmType {
 }
 
 /// The hardware device area where the alarm originated.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum Device {
     Control,
     Pedestal,

--- a/nexrad-decode/src/messages/rda_status_data/alarm/summary.rs
+++ b/nexrad-decode/src/messages/rda_status_data/alarm/summary.rs
@@ -2,7 +2,6 @@ use crate::messages::primitive_aliases::Code2;
 use std::fmt::Debug;
 
 /// The RDA system's active alarm types.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Summary(Code2);
 
 impl Summary {
@@ -48,5 +47,20 @@ impl Summary {
     /// Whether the signal processor alarm is active.
     pub fn signal_processor(&self) -> bool {
         self.0 & 0b1000000 != 0
+    }
+}
+
+impl Debug for Summary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Summary")
+            .field("none", &self.none())
+            .field("tower_utilities", &self.tower_utilities())
+            .field("pedestal", &self.pedestal())
+            .field("transmitter", &self.transmitter())
+            .field("receiver", &self.receiver())
+            .field("rda_control", &self.rda_control())
+            .field("communication", &self.communication())
+            .field("signal_processor", &self.signal_processor())
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/rda_status_data/alarm/summary.rs
+++ b/nexrad-decode/src/messages/rda_status_data/alarm/summary.rs
@@ -2,6 +2,7 @@ use crate::messages::primitive_aliases::Code2;
 use std::fmt::Debug;
 
 /// The RDA system's active alarm types.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Summary(Code2);
 
 impl Summary {
@@ -47,20 +48,5 @@ impl Summary {
     /// Whether the signal processor alarm is active.
     pub fn signal_processor(&self) -> bool {
         self.0 & 0b1000000 != 0
-    }
-}
-
-impl Debug for Summary {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Summary")
-            .field("none", &self.none())
-            .field("tower_utilities", &self.tower_utilities())
-            .field("pedestal", &self.pedestal())
-            .field("transmitter", &self.transmitter())
-            .field("receiver", &self.receiver())
-            .field("rda_control", &self.rda_control())
-            .field("communication", &self.communication())
-            .field("signal_processor", &self.signal_processor())
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/rda_status_data/alarm/summary.rs
+++ b/nexrad-decode/src/messages/rda_status_data/alarm/summary.rs
@@ -2,6 +2,7 @@ use crate::messages::primitive_aliases::Code2;
 use std::fmt::Debug;
 
 /// The RDA system's active alarm types.
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Summary(Code2);
 
 impl Summary {

--- a/nexrad-decode/src/messages/rda_status_data/data_transmission_enabled.rs
+++ b/nexrad-decode/src/messages/rda_status_data/data_transmission_enabled.rs
@@ -2,7 +2,6 @@ use crate::messages::primitive_aliases::Code2;
 use std::fmt::Debug;
 
 /// The types of data that have transmission enabled.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DataTransmissionEnabled(Code2);
 
 impl DataTransmissionEnabled {
@@ -28,5 +27,16 @@ impl DataTransmissionEnabled {
     /// Whether spectrum width data has transmission enabled.
     pub fn spectrum_width(&self) -> bool {
         self.0 & 0b1000 != 0
+    }
+}
+
+impl Debug for DataTransmissionEnabled {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DataTransmissionEnabled")
+            .field("none", &self.none())
+            .field("reflectivity", &self.reflectivity())
+            .field("velocity", &self.velocity())
+            .field("spectrum_width", &self.spectrum_width())
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/rda_status_data/data_transmission_enabled.rs
+++ b/nexrad-decode/src/messages/rda_status_data/data_transmission_enabled.rs
@@ -2,6 +2,7 @@ use crate::messages::primitive_aliases::Code2;
 use std::fmt::Debug;
 
 /// The types of data that have transmission enabled.
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct DataTransmissionEnabled(Code2);
 
 impl DataTransmissionEnabled {

--- a/nexrad-decode/src/messages/rda_status_data/data_transmission_enabled.rs
+++ b/nexrad-decode/src/messages/rda_status_data/data_transmission_enabled.rs
@@ -2,6 +2,7 @@ use crate::messages::primitive_aliases::Code2;
 use std::fmt::Debug;
 
 /// The types of data that have transmission enabled.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DataTransmissionEnabled(Code2);
 
 impl DataTransmissionEnabled {
@@ -27,16 +28,5 @@ impl DataTransmissionEnabled {
     /// Whether spectrum width data has transmission enabled.
     pub fn spectrum_width(&self) -> bool {
         self.0 & 0b1000 != 0
-    }
-}
-
-impl Debug for DataTransmissionEnabled {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DataTransmissionEnabled")
-            .field("none", &self.none())
-            .field("reflectivity", &self.reflectivity())
-            .field("velocity", &self.velocity())
-            .field("spectrum_width", &self.spectrum_width())
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/rda_status_data/definitions.rs
+++ b/nexrad-decode/src/messages/rda_status_data/definitions.rs
@@ -1,5 +1,5 @@
 /// Acknowledgement of command receipt by RDA system.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum CommandAcknowledgement {
     RemoteVCPReceived,
     ClutterBypassMapReceived,
@@ -8,7 +8,7 @@ pub enum CommandAcknowledgement {
 }
 
 /// The possible RDA system clutter mitigation decision statuses.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum ClutterMitigationDecisionStatus {
     Disabled,
     Enabled,
@@ -17,7 +17,7 @@ pub enum ClutterMitigationDecisionStatus {
 }
 
 /// The possible RDA system auxiliary power generator states.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum AuxiliaryPowerGeneratorState {
     SwitchedToAuxiliaryPower,
     UtilityPowerAvailable,
@@ -27,7 +27,7 @@ pub enum AuxiliaryPowerGeneratorState {
 }
 
 /// The possible RDA system control authorizations.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum ControlAuthorization {
     NoAction,
     LocalControlRequested,
@@ -35,7 +35,7 @@ pub enum ControlAuthorization {
 }
 
 /// The possible RDA system control statuses.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum ControlStatus {
     LocalControlOnly,
     RemoteControlOnly,
@@ -43,7 +43,7 @@ pub enum ControlStatus {
 }
 
 /// The possible RDA system operability statuses.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum OperabilityStatus {
     OnLine,
     MaintenanceActionRequired,
@@ -53,14 +53,14 @@ pub enum OperabilityStatus {
 }
 
 /// The possible RDA system operational modes.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum OperationalMode {
     Operational,
     Maintenance,
 }
 
 /// The RDA system's performance check status.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum PerformanceCheckStatus {
     NoCommandPending,
     ForcePerformanceCheckPending,
@@ -68,7 +68,7 @@ pub enum PerformanceCheckStatus {
 }
 
 /// The RDA system's RMS control status.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum RMSControlStatus {
     NonRMS,
     RMSInControl,
@@ -76,7 +76,7 @@ pub enum RMSControlStatus {
 }
 
 /// Indicates whether this is the RDA system's controlling channel.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum SpotBlankingStatus {
     NotInstalled,
     Enabled,
@@ -84,7 +84,7 @@ pub enum SpotBlankingStatus {
 }
 
 /// The possible RDA system statuses.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum RDAStatus {
     StartUp,
     Standby,
@@ -94,14 +94,14 @@ pub enum RDAStatus {
 }
 
 /// Whether the RDA system has super resolution enabled.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum SuperResolutionStatus {
     Enabled,
     Disabled,
 }
 
 /// The possible RDA system transition power source statuses.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum TransitionPowerSourceStatus {
     NotInstalled,
     Off,

--- a/nexrad-decode/src/messages/rda_status_data/message.rs
+++ b/nexrad-decode/src/messages/rda_status_data/message.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 /// The RDA status data message includes various information about the current RDA system's state,
 /// including system operating status, performance parameters, and active alarms.
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[derive(Deserialize)]
 pub struct Message {
     /// The RDA system's status.
     ///
@@ -464,5 +464,66 @@ impl Message {
             .filter(|&code| *code != 0)
             .filter_map(|&code| alarm::get_alarm_message(code))
             .collect()
+    }
+}
+
+impl Debug for Message {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Message")
+            .field("rda_status", &self.rda_status())
+            .field("operability_status", &self.operability_status())
+            .field("control_status", &self.control_status())
+            .field(
+                "auxiliary_power_generator_state",
+                &self.auxiliary_power_generator_state(),
+            )
+            .field("average_transmitter_power", &self.average_transmitter_power)
+            .field(
+                "horizontal_reflectivity_calibration_correction",
+                &self.horizontal_reflectivity_calibration_correction(),
+            )
+            .field(
+                "data_transmission_enabled",
+                &self.data_transmission_enabled(),
+            )
+            .field("volume_coverage_pattern", &self.volume_coverage_pattern())
+            .field(
+                "rda_control_authorization",
+                &self.rda_control_authorization(),
+            )
+            .field("rda_build_number", &self.rda_build_number())
+            .field("operational_mode", &self.operational_mode())
+            .field("super_resolution_status", &self.super_resolution_status())
+            .field(
+                "clutter_mitigation_decision_status",
+                &self.clutter_mitigation_decision_status(),
+            )
+            .field("rda_scan_and_data_flags", &self.rda_scan_and_data_flags())
+            .field("rda_alarm_summary", &self.rda_alarm_summary())
+            .field("command_acknowledgement", &self.command_acknowledgement())
+            .field("channel_control_status", &self.controlling_channel())
+            .field("spot_blanking_status", &self.spot_blanking_status())
+            .field(
+                "bypass_map_generation_date_time",
+                &self.bypass_map_generation_date_time(),
+            )
+            .field(
+                "clutter_filter_map_generation_date_time",
+                &self.clutter_filter_map_generation_date_time(),
+            )
+            .field(
+                "vertical_reflectivity_calibration_correction",
+                &self.vertical_reflectivity_calibration_correction,
+            )
+            .field(
+                "transition_power_source_status",
+                &self.transition_power_source_status(),
+            )
+            .field("rms_control_status", &self.rms_control_status())
+            .field("performance_check_status", &self.performance_check_status())
+            .field("alarm_messages", &self.alarm_messages())
+            .field("signal_processor_options", &self.signal_processor_options)
+            .field("status_version", &self.status_version)
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/rda_status_data/message.rs
+++ b/nexrad-decode/src/messages/rda_status_data/message.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 /// The RDA status data message includes various information about the current RDA system's state,
 /// including system operating status, performance parameters, and active alarms.
 #[repr(C)]
-#[derive(Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Deserialize)]
 pub struct Message {
     /// The RDA system's status.
     ///

--- a/nexrad-decode/src/messages/rda_status_data/message.rs
+++ b/nexrad-decode/src/messages/rda_status_data/message.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 /// The RDA status data message includes various information about the current RDA system's state,
 /// including system operating status, performance parameters, and active alarms.
 #[repr(C)]
-#[derive(Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
 pub struct Message {
     /// The RDA system's status.
     ///
@@ -464,66 +464,5 @@ impl Message {
             .filter(|&code| *code != 0)
             .filter_map(|&code| alarm::get_alarm_message(code))
             .collect()
-    }
-}
-
-impl Debug for Message {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Message")
-            .field("rda_status", &self.rda_status())
-            .field("operability_status", &self.operability_status())
-            .field("control_status", &self.control_status())
-            .field(
-                "auxiliary_power_generator_state",
-                &self.auxiliary_power_generator_state(),
-            )
-            .field("average_transmitter_power", &self.average_transmitter_power)
-            .field(
-                "horizontal_reflectivity_calibration_correction",
-                &self.horizontal_reflectivity_calibration_correction(),
-            )
-            .field(
-                "data_transmission_enabled",
-                &self.data_transmission_enabled(),
-            )
-            .field("volume_coverage_pattern", &self.volume_coverage_pattern())
-            .field(
-                "rda_control_authorization",
-                &self.rda_control_authorization(),
-            )
-            .field("rda_build_number", &self.rda_build_number())
-            .field("operational_mode", &self.operational_mode())
-            .field("super_resolution_status", &self.super_resolution_status())
-            .field(
-                "clutter_mitigation_decision_status",
-                &self.clutter_mitigation_decision_status(),
-            )
-            .field("rda_scan_and_data_flags", &self.rda_scan_and_data_flags())
-            .field("rda_alarm_summary", &self.rda_alarm_summary())
-            .field("command_acknowledgement", &self.command_acknowledgement())
-            .field("channel_control_status", &self.controlling_channel())
-            .field("spot_blanking_status", &self.spot_blanking_status())
-            .field(
-                "bypass_map_generation_date_time",
-                &self.bypass_map_generation_date_time(),
-            )
-            .field(
-                "clutter_filter_map_generation_date_time",
-                &self.clutter_filter_map_generation_date_time(),
-            )
-            .field(
-                "vertical_reflectivity_calibration_correction",
-                &self.vertical_reflectivity_calibration_correction,
-            )
-            .field(
-                "transition_power_source_status",
-                &self.transition_power_source_status(),
-            )
-            .field("rms_control_status", &self.rms_control_status())
-            .field("performance_check_status", &self.performance_check_status())
-            .field("alarm_messages", &self.alarm_messages())
-            .field("signal_processor_options", &self.signal_processor_options)
-            .field("status_version", &self.status_version)
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/rda_status_data/scan_data_flags.rs
+++ b/nexrad-decode/src/messages/rda_status_data/scan_data_flags.rs
@@ -2,7 +2,6 @@ use crate::messages::primitive_aliases::Code2;
 use std::fmt::Debug;
 
 /// The multiple flags for the RDA system's scan and data status.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ScanDataFlags(Code2);
 
 impl ScanDataFlags {
@@ -34,5 +33,19 @@ impl ScanDataFlags {
     /// Whether time series data recording is enabled.
     pub fn time_series_data_recording_enabled(&self) -> bool {
         self.0 & 0b10000 != 0
+    }
+}
+
+impl Debug for ScanDataFlags {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScanDataFlags")
+            .field("avset_enabled", &self.avset_enabled())
+            .field("ebc_enabled", &self.ebc_enabled())
+            .field("rda_log_data_enabled", &self.rda_log_data_enabled())
+            .field(
+                "time_series_data_recording_enabled",
+                &self.time_series_data_recording_enabled(),
+            )
+            .finish()
     }
 }

--- a/nexrad-decode/src/messages/rda_status_data/scan_data_flags.rs
+++ b/nexrad-decode/src/messages/rda_status_data/scan_data_flags.rs
@@ -2,6 +2,7 @@ use crate::messages::primitive_aliases::Code2;
 use std::fmt::Debug;
 
 /// The multiple flags for the RDA system's scan and data status.
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ScanDataFlags(Code2);
 
 impl ScanDataFlags {

--- a/nexrad-decode/src/messages/rda_status_data/scan_data_flags.rs
+++ b/nexrad-decode/src/messages/rda_status_data/scan_data_flags.rs
@@ -2,6 +2,7 @@ use crate::messages::primitive_aliases::Code2;
 use std::fmt::Debug;
 
 /// The multiple flags for the RDA system's scan and data status.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ScanDataFlags(Code2);
 
 impl ScanDataFlags {
@@ -33,19 +34,5 @@ impl ScanDataFlags {
     /// Whether time series data recording is enabled.
     pub fn time_series_data_recording_enabled(&self) -> bool {
         self.0 & 0b10000 != 0
-    }
-}
-
-impl Debug for ScanDataFlags {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ScanDataFlags")
-            .field("avset_enabled", &self.avset_enabled())
-            .field("ebc_enabled", &self.ebc_enabled())
-            .field("rda_log_data_enabled", &self.rda_log_data_enabled())
-            .field(
-                "time_series_data_recording_enabled",
-                &self.time_series_data_recording_enabled(),
-            )
-            .finish()
     }
 }

--- a/nexrad-decode/src/messages/rda_status_data/volume_coverage_pattern.rs
+++ b/nexrad-decode/src/messages/rda_status_data/volume_coverage_pattern.rs
@@ -2,6 +2,7 @@ use crate::messages::primitive_aliases::SInteger2;
 use std::fmt::Debug;
 
 /// The RDA system's volume coverage pattern number.
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct VolumeCoveragePatternNumber(SInteger2);
 
 impl VolumeCoveragePatternNumber {

--- a/nexrad-decode/src/messages/rda_status_data/volume_coverage_pattern.rs
+++ b/nexrad-decode/src/messages/rda_status_data/volume_coverage_pattern.rs
@@ -24,3 +24,13 @@ impl VolumeCoveragePatternNumber {
         self.0 > 0
     }
 }
+
+impl Debug for VolumeCoveragePatternNumber {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VolumeCoveragePatternNumber")
+            .field("number", &self.number())
+            .field("local", &self.local())
+            .field("remote", &self.remote())
+            .finish()
+    }
+}

--- a/nexrad-decode/src/messages/rda_status_data/volume_coverage_pattern.rs
+++ b/nexrad-decode/src/messages/rda_status_data/volume_coverage_pattern.rs
@@ -24,13 +24,3 @@ impl VolumeCoveragePatternNumber {
         self.0 > 0
     }
 }
-
-impl Debug for VolumeCoveragePatternNumber {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VolumeCoveragePatternNumber")
-            .field("number", &self.number())
-            .field("local", &self.local())
-            .field("remote", &self.remote())
-            .finish()
-    }
-}

--- a/nexrad-decode/src/summarize.rs
+++ b/nexrad-decode/src/summarize.rs
@@ -1,0 +1,213 @@
+use crate::messages::digital_radar_data;
+use crate::messages::{Message, MessageType, MessageWithHeader};
+use chrono::{DateTime, Utc};
+use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+
+/// Summary of a set of messages.
+#[derive(Clone, PartialEq)]
+pub struct MessageSummary {
+    /// The distinct volume coverage patterns found in these messages.
+    pub volume_coverage_patterns: HashSet<digital_radar_data::VolumeCoveragePattern>,
+
+    /// The number of messages of each type in the order they appear. Multiple messages of the same
+    /// type will be grouped together if consecutive.
+    pub message_types: Vec<(MessageType, usize)>,
+
+    /// Summaries of each scan found in these messages.
+    pub scans: Vec<ScanSummary>,
+
+    pub earliest_collection_time: Option<DateTime<Utc>>,
+    pub latest_collection_time: Option<DateTime<Utc>>,
+}
+
+impl Debug for MessageSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("MessageSummary");
+        debug.field("volume_coverage_patterns", &self.volume_coverage_patterns);
+
+        let message_types_string = self
+            .message_types
+            .iter()
+            .map(|(k, v)| format!("{:?}: {}", k, v))
+            .collect::<Vec<_>>();
+
+        debug.field("message_types", &message_types_string);
+
+        debug.field("scans", &self.scans);
+        debug.field("earliest_collection_time", &self.earliest_collection_time);
+        debug.field("latest_collection_time", &self.latest_collection_time);
+        debug.finish()
+    }
+}
+
+/// Summary of a single scan.
+#[derive(Clone, PartialEq)]
+pub struct ScanSummary {
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+
+    pub elevation: u8,
+
+    pub start_azimuth: f32,
+    pub end_azimuth: f32,
+
+    /// The number of messages containing a given radar data type.
+    pub data_types: HashMap<String, usize>,
+}
+
+impl Debug for ScanSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("ScanSummary");
+        debug.field("start_time", &self.start_time);
+        debug.field("end_time", &self.end_time);
+        debug.field("elevation", &self.elevation);
+        debug.field("start_azimuth", &self.start_azimuth);
+        debug.field("end_azimuth", &self.end_azimuth);
+
+        let data_types_string = self
+            .data_types
+            .iter()
+            .map(|(k, v)| format!("{}: {}", k, v))
+            .collect::<Vec<_>>();
+
+        debug.field("data_types", &data_types_string);
+
+        debug.finish()
+    }
+}
+
+/// Provides a summary of the given messages.
+pub fn messages(messages: &[MessageWithHeader]) -> MessageSummary {
+    let mut summary = MessageSummary {
+        volume_coverage_patterns: HashSet::new(),
+        message_types: Vec::new(),
+        scans: Vec::new(),
+        earliest_collection_time: None,
+        latest_collection_time: None,
+    };
+
+    if let Some(first_message) = messages.first() {
+        summary.earliest_collection_time = first_message.header.date_time();
+    }
+
+    let mut scan_summary = None;
+    for message_with_header in messages {
+        process_message(&mut summary, &mut scan_summary, message_with_header);
+    }
+
+    if let Some(scan_summary) = scan_summary.take() {
+        summary.scans.push(scan_summary);
+    }
+
+    summary
+}
+
+fn process_message(
+    summary: &mut MessageSummary,
+    scan_summary: &mut Option<ScanSummary>,
+    message_with_header: &MessageWithHeader,
+) {
+    let message_type = message_with_header.header.message_type();
+    if let Some((last_message_type, count)) = summary.message_types.last_mut() {
+        if *last_message_type == message_type {
+            *count += 1;
+        } else {
+            summary.message_types.push((message_type, 1));
+        }
+    } else {
+        summary.message_types.push((message_type, 1));
+    }
+
+    match &message_with_header.message {
+        Message::DigitalRadarData(message) => {
+            process_digital_radar_data_message(summary, scan_summary, message);
+            return;
+        }
+        _ => {}
+    }
+
+    if let Some(scan_summary) = scan_summary.take() {
+        summary.scans.push(scan_summary);
+    }
+}
+
+fn process_digital_radar_data_message(
+    summary: &mut MessageSummary,
+    scan_summary: &mut Option<ScanSummary>,
+    message: &digital_radar_data::Message,
+) {
+    let elevation_changed =
+        |summary: &mut ScanSummary| summary.elevation != message.header.elevation_number;
+
+    if let Some(scan_summary) = scan_summary.take_if(elevation_changed) {
+        summary.scans.push(scan_summary);
+    }
+
+    let scan_summary = scan_summary.get_or_insert_with(|| ScanSummary {
+        start_time: message.header.date_time(),
+        end_time: message.header.date_time(),
+        elevation: message.header.elevation_number,
+        start_azimuth: message.header.azimuth_angle,
+        end_azimuth: message.header.azimuth_angle,
+        data_types: HashMap::new(),
+    });
+
+    if message.header.date_time().is_some() {
+        if summary.earliest_collection_time.is_none()
+            || summary.earliest_collection_time > message.header.date_time()
+        {
+            summary.earliest_collection_time = message.header.date_time();
+        }
+
+        if summary.latest_collection_time.is_none()
+            || summary.latest_collection_time < message.header.date_time()
+        {
+            summary.latest_collection_time = message.header.date_time();
+        }
+
+        if scan_summary.start_time.is_none() || scan_summary.start_time > message.header.date_time()
+        {
+            scan_summary.start_time = message.header.date_time();
+        }
+
+        if scan_summary.end_time.is_none() || scan_summary.end_time < message.header.date_time() {
+            scan_summary.end_time = message.header.date_time();
+        }
+    }
+
+    if let Some(volume_data) = &message.volume_data_block {
+        summary
+            .volume_coverage_patterns
+            .insert(volume_data.volume_coverage_pattern());
+    }
+
+    scan_summary.end_azimuth = message.header.azimuth_angle;
+
+    let mut increment_count = |data_type: &str| {
+        let count = scan_summary.data_types.get(data_type).unwrap_or(&0) + 1;
+        scan_summary.data_types.insert(data_type.to_string(), count);
+    };
+
+    if message.reflectivity_data_block.is_some() {
+        increment_count("Reflectivity");
+    }
+    if message.velocity_data_block.is_some() {
+        increment_count("Velocity");
+    }
+    if message.spectrum_width_data_block.is_some() {
+        increment_count("Spectrum Width");
+    }
+    if message.differential_reflectivity_data_block.is_some() {
+        increment_count("Differential Reflectivity");
+    }
+    if message.differential_phase_data_block.is_some() {
+        increment_count("Differential Phase");
+    }
+    if message.correlation_coefficient_data_block.is_some() {
+        increment_count("Correlation Coefficient");
+    }
+    if message.specific_diff_phase_data_block.is_some() {
+        increment_count("Specific Differential Phase");
+    }
+}

--- a/nexrad-model/src/data/moment.rs
+++ b/nexrad-model/src/data/moment.rs
@@ -4,7 +4,6 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
 /// Moment data from a radial for a particular product where each value corresponds to a gate.
-#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MomentData {
     scale: f32,
@@ -39,6 +38,14 @@ impl MomentData {
                 _ => MomentValue::Value((raw_value as f32 - self.offset) / self.scale),
             })
             .collect()
+    }
+}
+
+impl Debug for MomentData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MomentData")
+            .field("values", &self.values())
+            .finish()
     }
 }
 

--- a/nexrad-model/src/data/moment.rs
+++ b/nexrad-model/src/data/moment.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
 /// Moment data from a radial for a particular product where each value corresponds to a gate.
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MomentData {
     scale: f32,
@@ -51,7 +52,7 @@ impl Debug for MomentData {
 
 /// The data moment value for a product in a radial's gate. The value may be a floating-point number
 /// or a special case such as "below threshold" or "range folded".
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum MomentValue {
     /// The data moment value for a gate.
     Value(f32),

--- a/nexrad-model/src/data/moment.rs
+++ b/nexrad-model/src/data/moment.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
 /// Moment data from a radial for a particular product where each value corresponds to a gate.
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MomentData {
     scale: f32,
@@ -38,14 +39,6 @@ impl MomentData {
                 _ => MomentValue::Value((raw_value as f32 - self.offset) / self.scale),
             })
             .collect()
-    }
-}
-
-impl Debug for MomentData {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MomentData")
-            .field("values", &self.values())
-            .finish()
     }
 }
 

--- a/nexrad-model/src/data/radial.rs
+++ b/nexrad-model/src/data/radial.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 /// elevation angle pair at a point in time and contains the Level II data (reflectivity, velocity,
 /// and spectrum width) for each range gate in that ray. The range of the radar and gate interval
 /// distance determines the resolution of the ray and the number of gates in the ray.
-#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Radial {
     collection_timestamp: i64,
@@ -169,8 +168,62 @@ impl Radial {
     }
 }
 
+impl Debug for Radial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("Radial");
+
+        debug.field("collection_timestamp", &self.collection_timestamp());
+
+        #[cfg(feature = "chrono")]
+        debug.field("collection_time", &self.collection_time());
+
+        debug.field("azimuth_number", &self.azimuth_number());
+
+        debug.field("azimuth_angle_degrees", &self.azimuth_angle_degrees());
+
+        #[cfg(feature = "uom")]
+        debug.field("azimuth_angle", &self.azimuth());
+
+        debug.field("azimuth_spacing_degrees", &self.azimuth_spacing_degrees());
+
+        #[cfg(feature = "uom")]
+        debug.field("azimuth_spacing", &self.azimuth_spacing());
+
+        debug.field("radial_status", &self.radial_status());
+
+        debug.field("elevation_number", &self.elevation_number());
+
+        debug.field("elevation_angle_degrees", &self.elevation_angle_degrees());
+
+        #[cfg(feature = "uom")]
+        debug.field("elevation_angle", &self.elevation_angle());
+
+        debug.field("reflectivity", &self.reflectivity());
+
+        debug.field("velocity", &self.velocity());
+
+        debug.field("spectrum_width", &self.spectrum_width());
+
+        debug.field(
+            "differential_reflectivity",
+            &self.differential_reflectivity(),
+        );
+
+        debug.field("differential_phase", &self.differential_phase());
+
+        debug.field("correlation_coefficient", &self.correlation_coefficient());
+
+        debug.field(
+            "specific_differential_phase",
+            &self.specific_differential_phase(),
+        );
+
+        debug.finish()
+    }
+}
+
 /// Describe a radial's position within the sequence of radials comprising a scan.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum RadialStatus {
     ElevationStart,

--- a/nexrad-model/src/data/radial.rs
+++ b/nexrad-model/src/data/radial.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 /// elevation angle pair at a point in time and contains the Level II data (reflectivity, velocity,
 /// and spectrum width) for each range gate in that ray. The range of the radar and gate interval
 /// distance determines the resolution of the ray and the number of gates in the ray.
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Radial {
     collection_timestamp: i64,
@@ -168,62 +169,8 @@ impl Radial {
     }
 }
 
-impl Debug for Radial {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut debug = f.debug_struct("Radial");
-
-        debug.field("collection_timestamp", &self.collection_timestamp());
-
-        #[cfg(feature = "chrono")]
-        debug.field("collection_time", &self.collection_time());
-
-        debug.field("azimuth_number", &self.azimuth_number());
-
-        debug.field("azimuth_angle_degrees", &self.azimuth_angle_degrees());
-
-        #[cfg(feature = "uom")]
-        debug.field("azimuth_angle", &self.azimuth());
-
-        debug.field("azimuth_spacing_degrees", &self.azimuth_spacing_degrees());
-
-        #[cfg(feature = "uom")]
-        debug.field("azimuth_spacing", &self.azimuth_spacing());
-
-        debug.field("radial_status", &self.radial_status());
-
-        debug.field("elevation_number", &self.elevation_number());
-
-        debug.field("elevation_angle_degrees", &self.elevation_angle_degrees());
-
-        #[cfg(feature = "uom")]
-        debug.field("elevation_angle", &self.elevation_angle());
-
-        debug.field("reflectivity", &self.reflectivity());
-
-        debug.field("velocity", &self.velocity());
-
-        debug.field("spectrum_width", &self.spectrum_width());
-
-        debug.field(
-            "differential_reflectivity",
-            &self.differential_reflectivity(),
-        );
-
-        debug.field("differential_phase", &self.differential_phase());
-
-        debug.field("correlation_coefficient", &self.correlation_coefficient());
-
-        debug.field(
-            "specific_differential_phase",
-            &self.specific_differential_phase(),
-        );
-
-        debug.finish()
-    }
-}
-
 /// Describe a radial's position within the sequence of radials comprising a scan.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum RadialStatus {
     ElevationStart,

--- a/nexrad-model/src/data/radial.rs
+++ b/nexrad-model/src/data/radial.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 /// elevation angle pair at a point in time and contains the Level II data (reflectivity, velocity,
 /// and spectrum width) for each range gate in that ray. The range of the radar and gate interval
 /// distance determines the resolution of the ray and the number of gates in the ray.
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Radial {
     collection_timestamp: i64,
@@ -223,7 +224,7 @@ impl Debug for Radial {
 }
 
 /// Describe a radial's position within the sequence of radials comprising a scan.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum RadialStatus {
     ElevationStart,

--- a/nexrad-model/src/data/scan.rs
+++ b/nexrad-model/src/data/scan.rs
@@ -1,14 +1,12 @@
 use crate::data::Sweep;
 use std::fmt::Debug;
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 /// A single radar scan composed of a series of sweeps. This represents a single volume scan which
 /// is composed of multiple sweeps at different elevations. The pattern of sweeps, including
 /// elevations and resolution, is determined by the scanning strategy of the radar. This is
 /// referred to as the Volume Coverage Pattern.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Scan {
     coverage_pattern_number: u16,
     sweeps: Vec<Sweep>,
@@ -31,14 +29,5 @@ impl Scan {
     /// The elevation sweeps comprising this scan.
     pub fn sweeps(&self) -> &Vec<Sweep> {
         self.sweeps.as_ref()
-    }
-}
-
-impl Debug for Scan {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Scan")
-            .field("coverage_pattern_number", &self.coverage_pattern_number())
-            .field("sweeps", &self.sweeps())
-            .finish()
     }
 }

--- a/nexrad-model/src/data/scan.rs
+++ b/nexrad-model/src/data/scan.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 /// is composed of multiple sweeps at different elevations. The pattern of sweeps, including
 /// elevations and resolution, is determined by the scanning strategy of the radar. This is
 /// referred to as the Volume Coverage Pattern.
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Scan {
     coverage_pattern_number: u16,

--- a/nexrad-model/src/data/scan.rs
+++ b/nexrad-model/src/data/scan.rs
@@ -1,12 +1,14 @@
 use crate::data::Sweep;
 use std::fmt::Debug;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// A single radar scan composed of a series of sweeps. This represents a single volume scan which
 /// is composed of multiple sweeps at different elevations. The pattern of sweeps, including
 /// elevations and resolution, is determined by the scanning strategy of the radar. This is
 /// referred to as the Volume Coverage Pattern.
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Scan {
     coverage_pattern_number: u16,
     sweeps: Vec<Sweep>,
@@ -29,5 +31,14 @@ impl Scan {
     /// The elevation sweeps comprising this scan.
     pub fn sweeps(&self) -> &Vec<Sweep> {
         self.sweeps.as_ref()
+    }
+}
+
+impl Debug for Scan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Scan")
+            .field("coverage_pattern_number", &self.coverage_pattern_number())
+            .field("sweeps", &self.sweeps())
+            .finish()
     }
 }

--- a/nexrad-model/src/data/sweep.rs
+++ b/nexrad-model/src/data/sweep.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 /// spectrum width) for each azimuth angle in that sweep. The resolution of the sweep dictates the
 /// azimuthal distance between rays and thus and number of rays in the sweep. Multiple sweeps are
 /// taken at different elevation angles to create a volume scan.
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Sweep {
     elevation_number: u8,
@@ -73,31 +74,5 @@ impl Sweep {
             elevation_number: self.elevation_number,
             radials,
         })
-    }
-}
-
-impl Display for Sweep {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let (Some(first), Some(last)) = (self.radials.first(), self.radials.last()) {
-            write!(
-                f,
-                "Sweep ({:.1}-{:.1} deg, {} radials, {} deg spacing)",
-                first.azimuth_angle_degrees(),
-                last.azimuth_angle_degrees(),
-                self.radials.len(),
-                first.azimuth_spacing_degrees()
-            )
-        } else {
-            write!(f, "Sweep (no radials)")
-        }
-    }
-}
-
-impl Debug for Sweep {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Sweep")
-            .field("elevation_number", &self.elevation_number())
-            .field("radials", &self.radials())
-            .finish()
     }
 }

--- a/nexrad-model/src/data/sweep.rs
+++ b/nexrad-model/src/data/sweep.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 /// spectrum width) for each azimuth angle in that sweep. The resolution of the sweep dictates the
 /// azimuthal distance between rays and thus and number of rays in the sweep. Multiple sweeps are
 /// taken at different elevation angles to create a volume scan.
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Sweep {
     elevation_number: u8,

--- a/nexrad-model/src/data/sweep.rs
+++ b/nexrad-model/src/data/sweep.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 /// spectrum width) for each azimuth angle in that sweep. The resolution of the sweep dictates the
 /// azimuthal distance between rays and thus and number of rays in the sweep. Multiple sweeps are
 /// taken at different elevation angles to create a volume scan.
-#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Sweep {
     elevation_number: u8,
@@ -74,5 +73,31 @@ impl Sweep {
             elevation_number: self.elevation_number,
             radials,
         })
+    }
+}
+
+impl Display for Sweep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let (Some(first), Some(last)) = (self.radials.first(), self.radials.last()) {
+            write!(
+                f,
+                "Sweep ({:.1}-{:.1} deg, {} radials, {} deg spacing)",
+                first.azimuth_angle_degrees(),
+                last.azimuth_angle_degrees(),
+                self.radials.len(),
+                first.azimuth_spacing_degrees()
+            )
+        } else {
+            write!(f, "Sweep (no radials)")
+        }
+    }
+}
+
+impl Debug for Sweep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Sweep")
+            .field("elevation_number", &self.elevation_number())
+            .field("radials", &self.radials())
+            .finish()
     }
 }

--- a/nexrad-model/src/meta.rs
+++ b/nexrad-model/src/meta.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use uom::si::{f32::Length, length::meter};
 
 /// A radar site's metadata including a variety of infrequently-changing properties.
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Site {
     identifier: [u8; 4],

--- a/nexrad-model/src/meta.rs
+++ b/nexrad-model/src/meta.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use uom::si::{f32::Length, length::meter};
 
 /// A radar site's metadata including a variety of infrequently-changing properties.
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Site {
     identifier: [u8; 4],
@@ -80,29 +81,5 @@ impl Site {
     #[cfg(feature = "uom")]
     pub fn feedhorn_height(&self) -> Length {
         Length::new::<meter>(self.feedhorn_height_meters as f32)
-    }
-}
-
-impl Debug for Site {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut debug = f.debug_struct("Site");
-
-        debug.field("identifier", &self.identifier_string());
-
-        debug.field("latitude_degrees", &self.latitude());
-
-        debug.field("longitude_degrees", &self.longitude());
-
-        debug.field("height_meters", &self.height_meters());
-
-        #[cfg(feature = "uom")]
-        debug.field("height", &self.height());
-
-        debug.field("feedhorn_height_meters", &self.feedhorn_height_meters());
-
-        #[cfg(feature = "uom")]
-        debug.field("feedhorn_height", &self.feedhorn_height());
-
-        debug.finish()
     }
 }

--- a/nexrad-model/src/meta.rs
+++ b/nexrad-model/src/meta.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 use uom::si::{f32::Length, length::meter};
 
 /// A radar site's metadata including a variety of infrequently-changing properties.
-#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Site {
     identifier: [u8; 4],
@@ -81,5 +80,29 @@ impl Site {
     #[cfg(feature = "uom")]
     pub fn feedhorn_height(&self) -> Length {
         Length::new::<meter>(self.feedhorn_height_meters as f32)
+    }
+}
+
+impl Debug for Site {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("Site");
+
+        debug.field("identifier", &self.identifier_string());
+
+        debug.field("latitude_degrees", &self.latitude());
+
+        debug.field("longitude_degrees", &self.longitude());
+
+        debug.field("height_meters", &self.height_meters());
+
+        #[cfg(feature = "uom")]
+        debug.field("height", &self.height());
+
+        debug.field("feedhorn_height_meters", &self.feedhorn_height_meters());
+
+        #[cfg(feature = "uom")]
+        debug.field("feedhorn_height", &self.feedhorn_height());
+
+        debug.finish()
     }
 }


### PR DESCRIPTION
This introduces a new `nexrad-decode::summarize` API for producing aggregate statistics from messages which ease understanding of the radar's current behavior or inspection of volumes/chunks' contents.

Additionally, this derives common traits more consistently across structures, and it introduces some custom `Debug` implementations where they were missing.