### PR TITLE
Correct nyquist velocity calculation

### DIFF
--- a/nexrad-decode/src/messages/digital_radar_data/radial_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/radial_data_block.rs
@@ -53,7 +53,7 @@ impl RadialDataBlock {
     /// Nyquist velocity.
     #[cfg(feature = "uom")]
     pub fn nyquist_velocity(&self) -> Velocity {
-        Velocity::new::<uom::si::velocity::meter_per_second>(self.nyquist_velocity as f64)
+        Velocity::new::<uom::si::velocity::meter_per_second>(self.nyquist_velocity as f64 * 0.01)
     }
 }
 


### PR DESCRIPTION
## Problem

Nyquist velocity should be scaled, but isn't. This throws off calculations that depend on nyquist velocity, like dealiasing.

## Solution

Scale the nyquist velocity as specified in the control document.


<details>
<summary>Dealiasing example using `KDMX20240521_215236_V06`</summary>
Broken:
<img width="1392" alt="Screenshot 2024-12-26 at 1 33 31 PM" src="https://github.com/user-attachments/assets/37be9197-20dc-4220-98b8-76c284a0c63f" />
Fixed:
<img width="1392" alt="Screenshot 2024-12-26 at 1 33 05 PM" src="https://github.com/user-attachments/assets/cd271c44-2d1e-4f3c-9858-036a4981f054" />

</details>