### PR TITLE
Implement Message Type 5 (Volume Coverage Pattern)

### DIFF
--- a/nexrad-decode/src/messages.rs
+++ b/nexrad-decode/src/messages.rs
@@ -67,9 +67,9 @@ pub fn decode_message<R: Read + Seek>(
         MessageType::RDAStatusData => {
             Message::RDAStatusData(Box::new(decode_rda_status_message(message_reader)?))
         }
-        MessageType::RDAVolumeCoveragePattern => {
-            Message::VolumeCoveragePattern(Box::new(decode_volume_coverage_pattern(message_reader)?))
-        }
+        MessageType::RDAVolumeCoveragePattern => Message::VolumeCoveragePattern(Box::new(
+            decode_volume_coverage_pattern(message_reader)?,
+        )),
         // TODO: this message type is segmented which is not supported well currently
         // MessageType::RDAClutterFilterMap => {
         //     Message::ClutterFilterMap(Box::new(decode_clutter_filter_map(message_reader)?))

--- a/nexrad-decode/src/messages.rs
+++ b/nexrad-decode/src/messages.rs
@@ -59,11 +59,6 @@ pub fn decode_message<R: Read + Seek>(
         return Ok(Message::DigitalRadarData(Box::new(decoded_message)));
     }
 
-    if message_type == MessageType::RDAVolumeCoveragePattern {
-        let decoded_message = decode_volume_coverage_pattern(reader)?;
-        return Ok(Message::VolumeCoveragePattern(Box::new(decoded_message)));
-    }
-
     let mut message_buffer = [0; 2432 - size_of::<MessageHeader>()];
     reader.read_exact(&mut message_buffer)?;
 
@@ -71,6 +66,9 @@ pub fn decode_message<R: Read + Seek>(
     Ok(match message_type {
         MessageType::RDAStatusData => {
             Message::RDAStatusData(Box::new(decode_rda_status_message(message_reader)?))
+        }
+        MessageType::RDAVolumeCoveragePattern => {
+            Message::VolumeCoveragePattern(Box::new(decode_volume_coverage_pattern(message_reader)?))
         }
         // TODO: this message type is segmented which is not supported well currently
         // MessageType::RDAClutterFilterMap => {

--- a/nexrad-decode/src/messages.rs
+++ b/nexrad-decode/src/messages.rs
@@ -2,6 +2,7 @@ pub mod clutter_filter_map;
 pub mod digital_radar_data;
 pub mod message_header;
 pub mod rda_status_data;
+pub mod volume_coverage_pattern;
 
 mod message_type;
 pub use message_type::MessageType;
@@ -15,6 +16,7 @@ mod primitive_aliases;
 use crate::messages::digital_radar_data::decode_digital_radar_data;
 use crate::messages::message_header::MessageHeader;
 use crate::messages::rda_status_data::decode_rda_status_message;
+use crate::messages::volume_coverage_pattern::decode_volume_coverage_pattern;
 use crate::result::Result;
 use crate::util::deserialize;
 use log::{debug, trace};
@@ -55,6 +57,11 @@ pub fn decode_message<R: Read + Seek>(
     if message_type == MessageType::RDADigitalRadarDataGenericFormat {
         let decoded_message = decode_digital_radar_data(reader)?;
         return Ok(Message::DigitalRadarData(Box::new(decoded_message)));
+    }
+
+    if message_type == MessageType::RDAVolumeCoveragePattern {
+        let decoded_message = decode_volume_coverage_pattern(reader)?;
+        return Ok(Message::VolumeCoveragePattern(Box::new(decoded_message)));
     }
 
     let mut message_buffer = [0; 2432 - size_of::<MessageHeader>()];

--- a/nexrad-decode/src/messages/message.rs
+++ b/nexrad-decode/src/messages/message.rs
@@ -2,6 +2,7 @@ use crate::messages::clutter_filter_map;
 use crate::messages::digital_radar_data;
 use crate::messages::message_header::MessageHeader;
 use crate::messages::rda_status_data;
+use crate::messages::volume_coverage_pattern;
 
 /// A decoded NEXRAD Level II message with its metadata header.
 #[derive(Debug, Clone, PartialEq)]
@@ -16,5 +17,6 @@ pub enum Message {
     RDAStatusData(Box<rda_status_data::Message>),
     DigitalRadarData(Box<digital_radar_data::Message>),
     ClutterFilterMap(Box<clutter_filter_map::Message>),
+    VolumeCoveragePattern(Box<volume_coverage_pattern::Message>),
     Other,
 }

--- a/nexrad-decode/src/messages/volume_coverage_pattern.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern.rs
@@ -3,7 +3,7 @@
 //! the number of elevation cuts and metadata about the entire volume, as well as a data
 //! block for each elevation with metadata about that specific cut such as the waveform
 //! type and other metadata.
-//! 
+//!
 
 mod definitions;
 pub use definitions::*;

--- a/nexrad-decode/src/messages/volume_coverage_pattern.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern.rs
@@ -1,16 +1,18 @@
 //!
-//! Message type 5 "Volume Coverage Pattern" consists of base VCP information such as
-//! the number of elevation cuts and metadata about the entire volume, as well as a data
-//! block for each elevation with metadata about that specific cut such as the waveform
-//! type and other metadata.
+//! Message type 5 "Volume Coverage Pattern" provides details about the volume
+//! coverage pattern being used. The RDA sends the Volume Coverage Pattern message
+//! upon wideband connection and at the beginning of each volume scan. The volume
+//! coverage pattern message includes a header which describes how the volume is being
+//! collected as well as a block for each elevation cut detailing the radar settings
+//! being used for that cut.
 //!
+
+use std::io::Read;
 
 mod definitions;
 pub use definitions::*;
 
 mod header;
-use std::io::Read;
-
 pub use header::Header;
 
 mod message;

--- a/nexrad-decode/src/messages/volume_coverage_pattern.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern.rs
@@ -5,6 +5,9 @@
 //! type and other metadata.
 //! 
 
+mod definitions;
+pub use definitions::*;
+
 mod header;
 use std::io::Read;
 

--- a/nexrad-decode/src/messages/volume_coverage_pattern.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern.rs
@@ -6,7 +6,7 @@
 //! 
 
 mod header;
-use std::io::{Read, Seek};
+use std::io::Read;
 
 pub use header::Header;
 
@@ -20,7 +20,7 @@ use crate::result::Result;
 use crate::util::deserialize;
 
 /// Decodes a volume coverage pattern message type 5 from the provided reader.
-pub fn decode_volume_coverage_pattern<R: Read + Seek>(reader: &mut R) -> Result<Message> {
+pub fn decode_volume_coverage_pattern<R: Read>(reader: &mut R) -> Result<Message> {
     let header: Header = deserialize(reader)?;
 
     let mut elevations: Vec<ElevationDataBlock> = Vec::new();

--- a/nexrad-decode/src/messages/volume_coverage_pattern.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern.rs
@@ -1,0 +1,34 @@
+//!
+//! Message type 5 "Volume Coverage Pattern" consists of base VCP information such as
+//! the number of elevation cuts and metadata about the entire volume, as well as a data
+//! block for each elevation with metadata about that specific cut such as the waveform
+//! type and other metadata.
+//! 
+
+mod header;
+use std::io::{Read, Seek};
+
+pub use header::Header;
+
+mod message;
+pub use message::Message;
+
+mod elevation_data_block;
+pub use elevation_data_block::ElevationDataBlock;
+
+use crate::result::Result;
+use crate::util::deserialize;
+
+/// Decodes a volume coverage pattern message type 5 from the provided reader.
+pub fn decode_volume_coverage_pattern<R: Read + Seek>(reader: &mut R) -> Result<Message> {
+    let header: Header = deserialize(reader)?;
+
+    let mut elevations: Vec<ElevationDataBlock> = Vec::new();
+    for _ in 0..header.number_of_elevation_cuts {
+        elevations.push(deserialize(reader)?);
+    }
+
+    let message = Message::new(header, elevations);
+
+    Ok(message)
+}

--- a/nexrad-decode/src/messages/volume_coverage_pattern/definitions.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/definitions.rs
@@ -12,4 +12,3 @@ pub enum PulseWidth {
     Long,
     Unknown,
 }
-

--- a/nexrad-decode/src/messages/volume_coverage_pattern/definitions.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/definitions.rs
@@ -1,4 +1,4 @@
-/// Possible values for pattern types
+/// Possible values for the VCP pattern type
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum PatternType {
     Constant,
@@ -25,15 +25,10 @@ pub enum ChannelConfiguration {
 /// Possible values for waveform type
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum WaveformType {
-    CS,
-    /// Contiguous Surveillance
-    CDW,
-    /// Contiguous Doppler w/ Ambiguity Resolution
-    CDWO,
-    /// Contiguous Doppler w/o Ambiguity Resolution
-    B,
-    /// Batch
-    SPP,
-    /// Staggered Pulse Pair
+    CS,   // Contiguous Surveillance
+    CDW,  // Contiguous Doppler with Ambiguity Resolution
+    CDWO, // Contiguous Doppler without Ambiguity Resolution
+    B,    // Batch
+    SPP,  // Staggered Pulse Pair
     Unknown,
 }

--- a/nexrad-decode/src/messages/volume_coverage_pattern/definitions.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/definitions.rs
@@ -25,10 +25,15 @@ pub enum ChannelConfiguration {
 /// Possible values for waveform type
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum WaveformType {
-    CS,   // Contiguous Surveillance
-    CDW,  // Contiguous Doppler with Ambiguity Resolution
-    CDWO, // Contiguous Doppler without Ambiguity Resolution
-    B,    // Batch
-    SPP,  // Staggered Pulse Pair
+    /// Contiguous Surveillance
+    CS,
+    /// Contiguous Doppler with Ambiguity Resolution
+    CDW,
+    /// Contiguous Doppler without Ambiguity Resolution
+    CDWO,
+    /// Batch
+    B,
+    /// Staggered Pulse Pair
+    SPP,
     Unknown,
 }

--- a/nexrad-decode/src/messages/volume_coverage_pattern/definitions.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/definitions.rs
@@ -1,0 +1,15 @@
+/// Possible values for pattern types
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum PatternType {
+    Constant,
+    Unknown,
+}
+
+/// Possible values for pulse width
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum PulseWidth {
+    Short,
+    Long,
+    Unknown,
+}
+

--- a/nexrad-decode/src/messages/volume_coverage_pattern/definitions.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/definitions.rs
@@ -12,3 +12,28 @@ pub enum PulseWidth {
     Long,
     Unknown,
 }
+
+/// Possible values for channel configuration
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum ChannelConfiguration {
+    ConstantPhase,
+    RandomPhase,
+    SZ2Phase,
+    UnknownPhase,
+}
+
+/// Possible values for waveform type
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum WaveformType {
+    CS,
+    /// Contiguous Surveillance
+    CDW,
+    /// Contiguous Doppler w/ Ambiguity Resolution
+    CDWO,
+    /// Contiguous Doppler w/o Ambiguity Resolution
+    B,
+    /// Batch
+    SPP,
+    /// Staggered Pulse Pair
+    Unknown,
+}

--- a/nexrad-decode/src/messages/volume_coverage_pattern/elevation_data_block.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/elevation_data_block.rs
@@ -157,11 +157,11 @@ impl ElevationDataBlock {
     /// The waveform type for this cut
     pub fn waveform_type(&self) -> WaveformType {
         match self.waveform_type {
-            0 => WaveformType::CS,
-            1 => WaveformType::CDW,
+            1 => WaveformType::CS,
             2 => WaveformType::CDW,
-            3 => WaveformType::B,
-            4 => WaveformType::SPP,
+            3 => WaveformType::CDWO,
+            4 => WaveformType::B,
+            5 => WaveformType::SPP,
             _ => WaveformType::Unknown,
         }
     }

--- a/nexrad-decode/src/messages/volume_coverage_pattern/elevation_data_block.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/elevation_data_block.rs
@@ -1,0 +1,136 @@
+use serde::Deserialize;
+
+use crate::messages::primitive_aliases::{Code1, Code2, Integer1, Integer2, ScaledSInteger2};
+
+use std::fmt::Debug;
+
+/// A radial data moment block.
+#[derive(Clone, PartialEq, Deserialize)]
+pub struct ElevationDataBlock {
+    /// The elevation angle for this cut
+    pub elevation_angle: Code2,
+
+    /// The channel configuration for this cut
+    /// 0 => Constant Phase
+    /// 1 => Random Phase
+    /// 2 => SZ2 Phase
+    pub channel_configuration: Code1,
+
+    /// The waveform type for this cut
+    /// 1 => Contiguous Surveillance
+    /// 2 => Contiguous Doppler w/ Ambiguity Resolution
+    /// 3 => Contiguous Doppler w/o Ambiguity Resolution
+    /// 4 => Batch
+    /// 5 => Staggered Pulse Pair
+    pub waveform_types: Code1,
+
+    /// Super resolution control values for this cut
+    /// Bit 0: 0.5 degree azimuth
+    /// Bit 1: 1/4 km reflectivity
+    /// Bit 2: Doppler to 300 km
+    /// Bit 3: Dual polarization to 300 km
+    pub super_resolution_control: Code1,
+
+    /// The pulse repetition frequency number for surveillance cuts
+    pub surveillance_prf_number: Integer1,
+
+    /// The pulse count per radial for surveillance cuts
+    pub surveillance_prf_pulse_count_radial: Integer2,
+
+    /// The azimuth rate of the cut
+    pub azimuth_rate: Code2,
+
+    /// Signal to noise ratio (SNR) threshold for reflectivity
+    pub reflectivity_threshold: ScaledSInteger2,
+
+    /// Signal to noise ratio (SNR) threshold for velocity
+    pub velocity_threshold: ScaledSInteger2,
+
+    /// Signal to noise ratio (SNR) threshold for spectrum width
+    pub spectrum_width_threshold: ScaledSInteger2,
+
+    /// Signal to noise ratio (SNR) threshold for differential reflectivity
+    pub differential_reflectivity_threshold: ScaledSInteger2,
+
+    /// Signal to noise ratio (SNR) threshold for differential phase
+    pub differential_phase_threshold: ScaledSInteger2,
+
+    /// Signal to noise ratio (SNR) threshold for correlation coefficitn
+    pub correlation_coefficient_threshold: ScaledSInteger2,
+
+    /// Sector 1 Azimuth Clockwise Edge Angle (denotes start angle)
+    pub sector_1_edge_angle: Code2,
+
+    /// Sector 1 Doppler PRF Number
+    pub sector_1_doppler_prf_number: Integer2,
+
+    /// Sector 1 Doppler Pulse Count/Radial
+    pub sector_1_doppler_prf_pulse_count_radial: Integer2,
+
+    /// Supplemental Data
+    /// Bit 0:    SAILS Cut
+    /// Bits 1-3: SAILS Sequence Number
+    /// Bit 4:    MRLE Cut
+    /// Bits 5-7: MRLE Sequence Number
+    /// Bit 8:    Spare
+    /// Bit 9:    MPDA Cut
+    /// Bit 10:   BASE TILT Cut
+    pub vcp_supplemental_data: Code2,
+
+    /// Sector 2 Azimuth Clockwise Edge Angle (denotes start angle)
+    pub sector_2_edge_angle: Code2,
+
+    /// Sector 2 Doppler PRF Number
+    pub sector_2_doppler_prf_number: Integer2,
+
+    /// Sector 2 Doppler Pulse Count/Radial
+    pub sector_2_doppler_prf_pulse_count_radial: Integer2,
+
+    /// The correction added to the elevation angle for this cut
+    pub ebc_angle: Code2,
+
+    /// Sector 3 Azimuth Clockwise Edge Angle (denotes start angle)
+    pub sector_3_edge_angle: Code2,
+
+    /// Sector 3 Doppler PRF Number
+    pub sector_3_doppler_prf_number: Integer2,
+
+    /// Sector 3 Doppler Pulse Count/Radial
+    pub sector_3_doppler_prf_pulse_count_radial: Integer2,
+
+    /// Reserved
+    pub reserved: Integer2,
+}
+
+
+impl Debug for ElevationDataBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ElevationDataBlock")
+            .field("elevation_angle", &self.elevation_angle)
+            .field("channel_configuration", &self.channel_configuration)
+            .field("waveform_types", &self.waveform_types)
+            .field("super_resolution_control", &self.super_resolution_control)
+            .field("surveillance_prf_number", &self.surveillance_prf_number)
+            .field("surveillance_prf_pulse_count_radial", &self.surveillance_prf_pulse_count_radial)
+            .field("azimuth_rate", &self.azimuth_rate)
+            .field("reflectivity_threshold", &self.reflectivity_threshold)
+            .field("velocity_threshold", &self.velocity_threshold)
+            .field("spectrum_width_threshold", &self.spectrum_width_threshold)
+            .field("differential_reflectivity_threshold", &self.differential_reflectivity_threshold)
+            .field("differential_phase_threshold", &self.differential_phase_threshold)
+            .field("correlation_coefficient_threshold", &self.correlation_coefficient_threshold)
+            .field("sector_1_edge_angle", &self.sector_1_edge_angle)
+            .field("sector_1_doppler_prf_number", &self.sector_1_doppler_prf_number)
+            .field("sector_1_doppler_prf_pulse_count_radial", &self.sector_1_doppler_prf_pulse_count_radial)
+            .field("vcp_supplemental_data", &self.vcp_supplemental_data)
+            .field("sector_2_edge_angle", &self.sector_2_edge_angle)
+            .field("sector_2_doppler_prf_number", &self.sector_2_doppler_prf_number)
+            .field("sector_2_doppler_prf_pulse_count_radial", &self.sector_2_doppler_prf_pulse_count_radial)
+            .field("ebc_angle", &self.ebc_angle)
+            .field("sector_3_edge_angle", &self.sector_3_edge_angle)
+            .field("sector_3_doppler_prf_number", &self.sector_3_doppler_prf_number)
+            .field("sector_3_doppler_prf_pulse_count_radial", &self.sector_3_doppler_prf_pulse_count_radial)
+            .field("reserved", &self.reserved)
+            .finish()
+    }
+}

--- a/nexrad-decode/src/messages/volume_coverage_pattern/elevation_data_block.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/elevation_data_block.rs
@@ -102,7 +102,6 @@ pub struct ElevationDataBlock {
     pub reserved: Integer2,
 }
 
-
 impl Debug for ElevationDataBlock {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ElevationDataBlock")
@@ -111,25 +110,55 @@ impl Debug for ElevationDataBlock {
             .field("waveform_types", &self.waveform_types)
             .field("super_resolution_control", &self.super_resolution_control)
             .field("surveillance_prf_number", &self.surveillance_prf_number)
-            .field("surveillance_prf_pulse_count_radial", &self.surveillance_prf_pulse_count_radial)
+            .field(
+                "surveillance_prf_pulse_count_radial",
+                &self.surveillance_prf_pulse_count_radial,
+            )
             .field("azimuth_rate", &self.azimuth_rate)
             .field("reflectivity_threshold", &self.reflectivity_threshold)
             .field("velocity_threshold", &self.velocity_threshold)
             .field("spectrum_width_threshold", &self.spectrum_width_threshold)
-            .field("differential_reflectivity_threshold", &self.differential_reflectivity_threshold)
-            .field("differential_phase_threshold", &self.differential_phase_threshold)
-            .field("correlation_coefficient_threshold", &self.correlation_coefficient_threshold)
+            .field(
+                "differential_reflectivity_threshold",
+                &self.differential_reflectivity_threshold,
+            )
+            .field(
+                "differential_phase_threshold",
+                &self.differential_phase_threshold,
+            )
+            .field(
+                "correlation_coefficient_threshold",
+                &self.correlation_coefficient_threshold,
+            )
             .field("sector_1_edge_angle", &self.sector_1_edge_angle)
-            .field("sector_1_doppler_prf_number", &self.sector_1_doppler_prf_number)
-            .field("sector_1_doppler_prf_pulse_count_radial", &self.sector_1_doppler_prf_pulse_count_radial)
+            .field(
+                "sector_1_doppler_prf_number",
+                &self.sector_1_doppler_prf_number,
+            )
+            .field(
+                "sector_1_doppler_prf_pulse_count_radial",
+                &self.sector_1_doppler_prf_pulse_count_radial,
+            )
             .field("vcp_supplemental_data", &self.vcp_supplemental_data)
             .field("sector_2_edge_angle", &self.sector_2_edge_angle)
-            .field("sector_2_doppler_prf_number", &self.sector_2_doppler_prf_number)
-            .field("sector_2_doppler_prf_pulse_count_radial", &self.sector_2_doppler_prf_pulse_count_radial)
+            .field(
+                "sector_2_doppler_prf_number",
+                &self.sector_2_doppler_prf_number,
+            )
+            .field(
+                "sector_2_doppler_prf_pulse_count_radial",
+                &self.sector_2_doppler_prf_pulse_count_radial,
+            )
             .field("ebc_angle", &self.ebc_angle)
             .field("sector_3_edge_angle", &self.sector_3_edge_angle)
-            .field("sector_3_doppler_prf_number", &self.sector_3_doppler_prf_number)
-            .field("sector_3_doppler_prf_pulse_count_radial", &self.sector_3_doppler_prf_pulse_count_radial)
+            .field(
+                "sector_3_doppler_prf_number",
+                &self.sector_3_doppler_prf_number,
+            )
+            .field(
+                "sector_3_doppler_prf_pulse_count_radial",
+                &self.sector_3_doppler_prf_pulse_count_radial,
+            )
             .field("reserved", &self.reserved)
             .finish()
     }

--- a/nexrad-decode/src/messages/volume_coverage_pattern/elevation_data_block.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/elevation_data_block.rs
@@ -111,9 +111,38 @@ pub struct ElevationDataBlock {
     pub reserved: Integer2,
 }
 
+/// Decodes an angle as defined in table III-A of the 2620002W ICD
+fn decode_angle(raw: Code2) -> Angle {
+    let mut angle: f64 = 0.0;
+    for i in 3..16 {
+        if ((raw >> i) & 1) == 1 {
+            angle += 180.0 * f64::powf(2.0, (i - 15) as f64);
+        }
+    }
+
+    Angle::new::<degree>(angle)
+}
+
+/// Decodes an angular velocity as defined in table XI-D of the 2620002W ICD
+fn decode_angular_velocity(raw: Code2) -> AngularVelocity {
+    let mut angular_velocity: f64 = 0.0;
+
+    for i in 3..15 {
+        if ((raw >> i) & 1) == 1 {
+            angular_velocity += 22.5 * f64::powf(2.0, (i - 14) as f64);
+        }
+    }
+
+    if ((raw >> 15) & 1) == 1 {
+        angular_velocity = -angular_velocity
+    }
+
+    AngularVelocity::new::<degree_per_second>(angular_velocity)
+}
+
 impl ElevationDataBlock {
     pub fn elevation_angle(&self) -> Angle {
-        Angle::new::<degree>(0.0)
+        decode_angle(self.elevation_angle)
     }
 
     pub fn channel_configuration(&self) -> ChannelConfiguration {
@@ -153,7 +182,7 @@ impl ElevationDataBlock {
     }
 
     pub fn azimuth_rate(&self) -> AngularVelocity {
-        AngularVelocity::new::<degree_per_second>(0.0)
+        decode_angular_velocity(self.azimuth_rate)
     }
 
     pub fn reflectivity_threshold(&self) -> f64 {
@@ -181,19 +210,19 @@ impl ElevationDataBlock {
     }
 
     pub fn sector_1_edge_angle(&self) -> Angle {
-        Angle::new::<degree>(0.0)
+        decode_angle(self.sector_1_edge_angle)
     }
 
     pub fn sector_2_edge_angle(&self) -> Angle {
-        Angle::new::<degree>(0.0)
+        decode_angle(self.sector_2_edge_angle)
     }
 
     pub fn sector_3_edge_angle(&self) -> Angle {
-        Angle::new::<degree>(0.0)
+        decode_angle(self.sector_3_edge_angle)
     }
 
     pub fn ebc_angle(&self) -> Angle {
-        Angle::new::<degree>(0.0)
+        decode_angle(self.ebc_angle)
     }
 
     pub fn supplemental_data_sails_cut(&self) -> bool {
@@ -221,6 +250,7 @@ impl ElevationDataBlock {
     }
 }
 
+#[cfg(not(feature = "uom"))]
 impl Debug for ElevationDataBlock {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ElevationDataBlock")
@@ -296,6 +326,112 @@ impl Debug for ElevationDataBlock {
                 &self.sector_3_doppler_prf_pulse_count_radial,
             )
             .field("ebc_angle", &self.ebc_angle)
+            .field("supplemental_data", &self.supplemental_data)
+            .field(
+                "supplemental_data_sails_cut",
+                &self.supplemental_data_sails_cut(),
+            )
+            .field(
+                "supplemental_data_sails_sequence_number",
+                &self.supplemental_data_sails_sequence_number(),
+            )
+            .field(
+                "supplemental_data_mrle_cut",
+                &self.supplemental_data_mrle_cut(),
+            )
+            .field(
+                "supplemental_data_mrle_sequence_number",
+                &self.supplemental_data_mrle_sequence_number(),
+            )
+            .field(
+                "supplemental_data_mpda_cut",
+                &self.supplemental_data_mpda_cut(),
+            )
+            .field(
+                "supplemental_data_base_tilt_cut",
+                &self.supplemental_data_base_tilt_cut(),
+            )
+            .field("reserved", &self.reserved)
+            .finish()
+    }
+}
+
+#[cfg(feature = "uom")]
+impl Debug for ElevationDataBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ElevationDataBlock")
+            .field("elevation_angle", &self.elevation_angle())
+            .field("channel_configuration", &self.channel_configuration())
+            .field("waveform_type", &self.waveform_type())
+            .field(
+                "super_resolution_control_raw",
+                &self.super_resolution_control,
+            )
+            .field(
+                "super_resolution_control_half_degree_azimuth",
+                &self.super_resolution_control_half_degree_azimuth(),
+            )
+            .field(
+                "super_resolution_control_quarter_km_reflectivity",
+                &self.super_resolution_control_quarter_km_reflectivity(),
+            )
+            .field(
+                "super_resolution_control_doppler_to_300km",
+                &self.super_resolution_control_doppler_to_300km(),
+            )
+            .field(
+                "super_resolution_control_dual_polarization_to_300km",
+                &self.super_resolution_control_dual_polarization_to_300km(),
+            )
+            .field("surveillance_prf_number", &self.surveillance_prf_number)
+            .field(
+                "surveillance_prf_pulse_count_radial",
+                &self.surveillance_prf_pulse_count_radial,
+            )
+            .field("azimuth_rate", &self.azimuth_rate())
+            .field("reflectivity_threshold", &self.reflectivity_threshold())
+            .field("velocity_threshold", &self.velocity_threshold())
+            .field("spectrum_width_threshold", &self.spectrum_width_threshold())
+            .field(
+                "differential_reflectivity_threshold",
+                &self.differential_reflectivity_threshold(),
+            )
+            .field(
+                "differential_phase_threshold",
+                &self.differential_phase_threshold(),
+            )
+            .field(
+                "correlation_coefficient_threshold",
+                &self.correlation_coefficient_threshold(),
+            )
+            .field("sector_1_edge_angle", &self.sector_1_edge_angle())
+            .field(
+                "sector_1_doppler_prf_number",
+                &self.sector_1_doppler_prf_number,
+            )
+            .field(
+                "sector_1_doppler_prf_pulse_count_radial",
+                &self.sector_1_doppler_prf_pulse_count_radial,
+            )
+            .field("sector_2_edge_angle", &self.sector_2_edge_angle())
+            .field(
+                "sector_2_doppler_prf_number",
+                &self.sector_2_doppler_prf_number,
+            )
+            .field(
+                "sector_2_doppler_prf_pulse_count_radial",
+                &self.sector_2_doppler_prf_pulse_count_radial,
+            )
+            .field("sector_3_edge_angle", &self.sector_3_edge_angle())
+            .field(
+                "sector_3_doppler_prf_number",
+                &self.sector_3_doppler_prf_number,
+            )
+            .field(
+                "sector_3_doppler_prf_pulse_count_radial",
+                &self.sector_3_doppler_prf_pulse_count_radial,
+            )
+            .field("ebc_angle", &self.ebc_angle())
             .field("supplemental_data", &self.supplemental_data)
             .field(
                 "supplemental_data_sails_cut",

--- a/nexrad-decode/src/messages/volume_coverage_pattern/header.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/header.rs
@@ -1,8 +1,6 @@
 use serde::Deserialize;
 
-use crate::messages::primitive_aliases::{
-    Code1, Code2, Integer1, Integer2, Integer4,
-};
+use crate::messages::primitive_aliases::{Code1, Code2, Integer1, Integer2, Integer4};
 
 use std::fmt::Debug;
 
@@ -151,22 +149,58 @@ impl Debug for Header {
             .field("number_of_elevation_cuts", &self.number_of_elevation_cuts)
             .field("version", &self.version)
             .field("clutter_map_group_number", &self.clutter_map_group_number)
-            .field("doppler_velocity_resolution", &self.doppler_velocity_resolution)
+            .field(
+                "doppler_velocity_resolution",
+                &self.doppler_velocity_resolution,
+            )
             .field("pulse_width", &self.pulse_width())
             .field("reserved_1", &self.reserved_1)
             .field("vcp_sequencing_raw", &self.vcp_sequencing)
-            .field("vcp_sequencing_number_of_elevations", &self.vcp_sequencing_number_of_elevations())
-            .field("vcp_sequencing_maximum_sails_cuts", &self.vcp_sequencing_maximum_sails_cuts())
-            .field("vcp_sequencing_sequence_active", &self.vcp_sequencing_sequence_active())
-            .field("vcp_sequencing_truncated_vcp", &self.vcp_sequencing_truncated_vcp())
+            .field(
+                "vcp_sequencing_number_of_elevations",
+                &self.vcp_sequencing_number_of_elevations(),
+            )
+            .field(
+                "vcp_sequencing_maximum_sails_cuts",
+                &self.vcp_sequencing_maximum_sails_cuts(),
+            )
+            .field(
+                "vcp_sequencing_sequence_active",
+                &self.vcp_sequencing_sequence_active(),
+            )
+            .field(
+                "vcp_sequencing_truncated_vcp",
+                &self.vcp_sequencing_truncated_vcp(),
+            )
             .field("vcp_supplemental_data_raw", &self.vcp_supplemental_data)
-            .field("vcp_supplemental_data_sails_vcp", &self.vcp_supplemental_data_sails_vcp())
-            .field("vcp_supplemental_data_number_sails_cuts", &self.vcp_supplemental_data_number_sails_cuts())
-            .field("vcp_supplemental_data_mrle_vcp", &self.vcp_supplemental_data_mrle_vcp())
-            .field("vcp_supplemental_data_number_mrle_cuts", &self.vcp_supplemental_data_number_mrle_cuts())
-            .field("vcp_supplemental_data_mpda_vcp", &self.vcp_supplemental_data_mpda_vcp())
-            .field("vcp_supplemental_data_base_tilt_vcp", &self.vcp_supplemental_data_base_tilt_vcp())
-            .field("vcp_supplemental_data_base_tilts", &self.vcp_supplemental_data_base_tilts())
+            .field(
+                "vcp_supplemental_data_sails_vcp",
+                &self.vcp_supplemental_data_sails_vcp(),
+            )
+            .field(
+                "vcp_supplemental_data_number_sails_cuts",
+                &self.vcp_supplemental_data_number_sails_cuts(),
+            )
+            .field(
+                "vcp_supplemental_data_mrle_vcp",
+                &self.vcp_supplemental_data_mrle_vcp(),
+            )
+            .field(
+                "vcp_supplemental_data_number_mrle_cuts",
+                &self.vcp_supplemental_data_number_mrle_cuts(),
+            )
+            .field(
+                "vcp_supplemental_data_mpda_vcp",
+                &self.vcp_supplemental_data_mpda_vcp(),
+            )
+            .field(
+                "vcp_supplemental_data_base_tilt_vcp",
+                &self.vcp_supplemental_data_base_tilt_vcp(),
+            )
+            .field(
+                "vcp_supplemental_data_base_tilts",
+                &self.vcp_supplemental_data_base_tilts(),
+            )
             .field("reserved_2", &self.reserved_2)
             .finish()
     }
@@ -182,22 +216,58 @@ impl Debug for Header {
             .field("number_of_elevation_cuts", &self.number_of_elevation_cuts)
             .field("version", &self.version)
             .field("clutter_map_group_number", &self.clutter_map_group_number)
-            .field("doppler_velocity_resolution", &self.doppler_velocity_resolution())
+            .field(
+                "doppler_velocity_resolution",
+                &self.doppler_velocity_resolution(),
+            )
             .field("pulse_width", &self.pulse_width())
             .field("reserved_1", &self.reserved_1)
             .field("vcp_sequencing_raw", &self.vcp_sequencing)
-            .field("vcp_sequencing_number_of_elevations", &self.vcp_sequencing_number_of_elevations())
-            .field("vcp_sequencing_maximum_sails_cuts", &self.vcp_sequencing_maximum_sails_cuts())
-            .field("vcp_sequencing_sequence_active", &self.vcp_sequencing_sequence_active())
-            .field("vcp_sequencing_truncated_vcp", &self.vcp_sequencing_truncated_vcp())
+            .field(
+                "vcp_sequencing_number_of_elevations",
+                &self.vcp_sequencing_number_of_elevations(),
+            )
+            .field(
+                "vcp_sequencing_maximum_sails_cuts",
+                &self.vcp_sequencing_maximum_sails_cuts(),
+            )
+            .field(
+                "vcp_sequencing_sequence_active",
+                &self.vcp_sequencing_sequence_active(),
+            )
+            .field(
+                "vcp_sequencing_truncated_vcp",
+                &self.vcp_sequencing_truncated_vcp(),
+            )
             .field("vcp_supplemental_data_raw", &self.vcp_supplemental_data)
-            .field("vcp_supplemental_data_sails_vcp", &self.vcp_supplemental_data_sails_vcp())
-            .field("vcp_supplemental_data_number_sails_cuts", &self.vcp_supplemental_data_number_sails_cuts())
-            .field("vcp_supplemental_data_mrle_vcp", &self.vcp_supplemental_data_mrle_vcp())
-            .field("vcp_supplemental_data_number_mrle_cuts", &self.vcp_supplemental_data_number_mrle_cuts())
-            .field("vcp_supplemental_data_mpda_vcp", &self.vcp_supplemental_data_mpda_vcp())
-            .field("vcp_supplemental_data_base_tilt_vcp", &self.vcp_supplemental_data_base_tilt_vcp())
-            .field("vcp_supplemental_data_base_tilts", &self.vcp_supplemental_data_base_tilts())
+            .field(
+                "vcp_supplemental_data_sails_vcp",
+                &self.vcp_supplemental_data_sails_vcp(),
+            )
+            .field(
+                "vcp_supplemental_data_number_sails_cuts",
+                &self.vcp_supplemental_data_number_sails_cuts(),
+            )
+            .field(
+                "vcp_supplemental_data_mrle_vcp",
+                &self.vcp_supplemental_data_mrle_vcp(),
+            )
+            .field(
+                "vcp_supplemental_data_number_mrle_cuts",
+                &self.vcp_supplemental_data_number_mrle_cuts(),
+            )
+            .field(
+                "vcp_supplemental_data_mpda_vcp",
+                &self.vcp_supplemental_data_mpda_vcp(),
+            )
+            .field(
+                "vcp_supplemental_data_base_tilt_vcp",
+                &self.vcp_supplemental_data_base_tilt_vcp(),
+            )
+            .field(
+                "vcp_supplemental_data_base_tilts",
+                &self.vcp_supplemental_data_base_tilts(),
+            )
             .field("reserved_2", &self.reserved_2)
             .finish()
     }

--- a/nexrad-decode/src/messages/volume_coverage_pattern/header.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/header.rs
@@ -1,9 +1,7 @@
 use serde::Deserialize;
-
-use crate::messages::primitive_aliases::{Code1, Code2, Integer1, Integer2, Integer4};
-
 use std::fmt::Debug;
 
+use crate::messages::primitive_aliases::{Code1, Code2, Integer1, Integer2, Integer4};
 use crate::messages::volume_coverage_pattern::definitions::*;
 
 #[cfg(feature = "uom")]
@@ -11,8 +9,7 @@ use uom::si::f64::Velocity;
 #[cfg(feature = "uom")]
 use uom::si::velocity::meter_per_second;
 
-/// The volume coverage pattern header block which contains information about the volume coverage pattern
-/// and the following data for each elevation
+/// The volume coverage pattern header block
 #[derive(Clone, PartialEq, Deserialize)]
 pub struct Header {
     /// Total message size in halfwords, including the header and all elevation blocks
@@ -21,13 +18,13 @@ pub struct Header {
     /// Pattern type is always 2
     pub pattern_type: Code2,
 
-    /// VCP Pattern Number
+    /// Volume Coverage Pattern Number
     pub pattern_number: Integer2,
 
-    /// Number of elevation cuts in one complete volume scan
+    /// Number of elevation cuts in the complete volume scan
     pub number_of_elevation_cuts: Integer2,
 
-    /// VCP version number
+    /// Volume Coverage Pattern Version Number
     pub version: Integer1,
 
     /// Clutter map groups are not currently implemented
@@ -77,6 +74,7 @@ impl Header {
         }
     }
 
+    /// The doppler velocity resolution of this coverage pattern
     #[cfg(feature = "uom")]
     pub fn doppler_velocity_resolution(&self) -> Option<Velocity> {
         match self.doppler_velocity_resolution {
@@ -86,6 +84,7 @@ impl Header {
         }
     }
 
+    /// The pulse width for this VCP
     pub fn pulse_width(&self) -> PulseWidth {
         match self.pulse_width {
             2 => PulseWidth::Short,
@@ -94,46 +93,57 @@ impl Header {
         }
     }
 
+    /// The number of elevations in the VCP
     pub fn vcp_sequencing_number_of_elevations(&self) -> u8 {
         (self.vcp_sequencing & 0x001F) as u8
     }
 
+    /// The maximum number of SAILS cuts allowed in this VCP
     pub fn vcp_sequencing_maximum_sails_cuts(&self) -> u8 {
         ((self.vcp_sequencing & 0x0060) >> 5) as u8
     }
 
+    /// Whether this VCP is a part of an active VCP sequence
     pub fn vcp_sequencing_sequence_active(&self) -> bool {
         ((self.vcp_sequencing & 0x2000) >> 13) == 1
     }
 
+    /// Whether this VCP is truncated
     pub fn vcp_sequencing_truncated_vcp(&self) -> bool {
         ((self.vcp_sequencing & 0x4000) >> 14) == 1
     }
 
+    /// Whether this VCP uses SAILS cuts
     pub fn vcp_supplemental_data_sails_vcp(&self) -> bool {
         (self.vcp_supplemental_data & 0x0001) == 1
     }
 
+    /// The number of SAILS cuts used by this VCP
     pub fn vcp_supplemental_data_number_sails_cuts(&self) -> u8 {
         ((self.vcp_supplemental_data & 0x000E) >> 1) as u8
     }
 
+    /// Whether this VCP uses MRLE cuts
     pub fn vcp_supplemental_data_mrle_vcp(&self) -> bool {
         ((self.vcp_supplemental_data & 0x0010) >> 4) == 1
     }
 
+    /// The number of MRLE cuts used by this VCP
     pub fn vcp_supplemental_data_number_mrle_cuts(&self) -> u8 {
         ((self.vcp_supplemental_data & 0x00E0) >> 5) as u8
     }
 
+    /// Whether this VCP is a Multi-PRF Dealiasing Algorithm (MPDA) VCP
     pub fn vcp_supplemental_data_mpda_vcp(&self) -> bool {
         ((self.vcp_supplemental_data & 0x0800) >> 11) == 1
     }
 
+    /// Whether this VCP contains BASE TILTS
     pub fn vcp_supplemental_data_base_tilt_vcp(&self) -> bool {
         ((self.vcp_supplemental_data & 0x1000) >> 12) == 1
     }
 
+    /// The number of BASE TILTS in this VCP
     pub fn vcp_supplemental_data_base_tilts(&self) -> u8 {
         ((self.vcp_supplemental_data & 0xE000) >> 13) as u8
     }

--- a/nexrad-decode/src/messages/volume_coverage_pattern/header.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/header.rs
@@ -5,9 +5,7 @@ use crate::messages::primitive_aliases::{Code1, Code2, Integer1, Integer2, Integ
 use crate::messages::volume_coverage_pattern::definitions::*;
 
 #[cfg(feature = "uom")]
-use uom::si::f64::Velocity;
-#[cfg(feature = "uom")]
-use uom::si::velocity::meter_per_second;
+use uom::si::{f64::Velocity, velocity::meter_per_second};
 
 /// The volume coverage pattern header block
 #[derive(Clone, PartialEq, Deserialize)]
@@ -84,6 +82,15 @@ impl Header {
         }
     }
 
+    /// The doppler velocity resolution of this coverage pattern in m/s
+    pub fn doppler_velocity_resolution_meters_per_second(&self) -> Option<f64> {
+        match self.doppler_velocity_resolution {
+            2 => Some(0.5),
+            4 => Some(1.0),
+            _ => None,
+        }
+    }
+
     /// The pulse width for this VCP
     pub fn pulse_width(&self) -> PulseWidth {
         match self.pulse_width {
@@ -149,136 +156,78 @@ impl Header {
     }
 }
 
-#[cfg(not(feature = "uom"))]
 impl Debug for Header {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Header")
-            .field("message_size", &self.message_size)
-            .field("pattern_type", &self.pattern_type())
-            .field("pattern_number", &self.pattern_number)
-            .field("number_of_elevation_cuts", &self.number_of_elevation_cuts)
-            .field("version", &self.version)
-            .field("clutter_map_group_number", &self.clutter_map_group_number)
-            .field(
-                "doppler_velocity_resolution",
-                &self.doppler_velocity_resolution,
-            )
-            .field("pulse_width", &self.pulse_width())
-            .field("reserved_1", &self.reserved_1)
-            .field("vcp_sequencing_raw", &self.vcp_sequencing)
-            .field(
-                "vcp_sequencing_number_of_elevations",
-                &self.vcp_sequencing_number_of_elevations(),
-            )
-            .field(
-                "vcp_sequencing_maximum_sails_cuts",
-                &self.vcp_sequencing_maximum_sails_cuts(),
-            )
-            .field(
-                "vcp_sequencing_sequence_active",
-                &self.vcp_sequencing_sequence_active(),
-            )
-            .field(
-                "vcp_sequencing_truncated_vcp",
-                &self.vcp_sequencing_truncated_vcp(),
-            )
-            .field("vcp_supplemental_data_raw", &self.vcp_supplemental_data)
-            .field(
-                "vcp_supplemental_data_sails_vcp",
-                &self.vcp_supplemental_data_sails_vcp(),
-            )
-            .field(
-                "vcp_supplemental_data_number_sails_cuts",
-                &self.vcp_supplemental_data_number_sails_cuts(),
-            )
-            .field(
-                "vcp_supplemental_data_mrle_vcp",
-                &self.vcp_supplemental_data_mrle_vcp(),
-            )
-            .field(
-                "vcp_supplemental_data_number_mrle_cuts",
-                &self.vcp_supplemental_data_number_mrle_cuts(),
-            )
-            .field(
-                "vcp_supplemental_data_mpda_vcp",
-                &self.vcp_supplemental_data_mpda_vcp(),
-            )
-            .field(
-                "vcp_supplemental_data_base_tilt_vcp",
-                &self.vcp_supplemental_data_base_tilt_vcp(),
-            )
-            .field(
-                "vcp_supplemental_data_base_tilts",
-                &self.vcp_supplemental_data_base_tilts(),
-            )
-            .field("reserved_2", &self.reserved_2)
-            .finish()
-    }
-}
+        let mut debug = f.debug_struct("Header");
 
-#[cfg(feature = "uom")]
-impl Debug for Header {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Header")
-            .field("message_size", &self.message_size)
-            .field("pattern_type", &self.pattern_type())
-            .field("pattern_number", &self.pattern_number)
-            .field("number_of_elevation_cuts", &self.number_of_elevation_cuts)
-            .field("version", &self.version)
-            .field("clutter_map_group_number", &self.clutter_map_group_number)
-            .field(
-                "doppler_velocity_resolution",
-                &self.doppler_velocity_resolution(),
-            )
-            .field("pulse_width", &self.pulse_width())
-            .field("reserved_1", &self.reserved_1)
-            .field("vcp_sequencing_raw", &self.vcp_sequencing)
-            .field(
-                "vcp_sequencing_number_of_elevations",
-                &self.vcp_sequencing_number_of_elevations(),
-            )
-            .field(
-                "vcp_sequencing_maximum_sails_cuts",
-                &self.vcp_sequencing_maximum_sails_cuts(),
-            )
-            .field(
-                "vcp_sequencing_sequence_active",
-                &self.vcp_sequencing_sequence_active(),
-            )
-            .field(
-                "vcp_sequencing_truncated_vcp",
-                &self.vcp_sequencing_truncated_vcp(),
-            )
-            .field("vcp_supplemental_data_raw", &self.vcp_supplemental_data)
-            .field(
-                "vcp_supplemental_data_sails_vcp",
-                &self.vcp_supplemental_data_sails_vcp(),
-            )
-            .field(
-                "vcp_supplemental_data_number_sails_cuts",
-                &self.vcp_supplemental_data_number_sails_cuts(),
-            )
-            .field(
-                "vcp_supplemental_data_mrle_vcp",
-                &self.vcp_supplemental_data_mrle_vcp(),
-            )
-            .field(
-                "vcp_supplemental_data_number_mrle_cuts",
-                &self.vcp_supplemental_data_number_mrle_cuts(),
-            )
-            .field(
-                "vcp_supplemental_data_mpda_vcp",
-                &self.vcp_supplemental_data_mpda_vcp(),
-            )
-            .field(
-                "vcp_supplemental_data_base_tilt_vcp",
-                &self.vcp_supplemental_data_base_tilt_vcp(),
-            )
-            .field(
-                "vcp_supplemental_data_base_tilts",
-                &self.vcp_supplemental_data_base_tilts(),
-            )
-            .field("reserved_2", &self.reserved_2)
-            .finish()
+        debug.field("message_size", &self.message_size);
+        debug.field("pattern_type", &self.pattern_type());
+        debug.field("pattern_number", &self.pattern_number);
+        debug.field("number_of_elevation_cuts", &self.number_of_elevation_cuts);
+        debug.field("version", &self.version);
+        debug.field("clutter_map_group_number", &self.clutter_map_group_number);
+
+        #[cfg(feature = "uom")]
+        debug.field(
+            "doppler_velocity_resolution",
+            &self.doppler_velocity_resolution(),
+        );
+        #[cfg(not(feature = "uom"))]
+        debug.field(
+            "doppler_velocity_resolution",
+            &self.doppler_velocity_resolution_meters_per_second(),
+        );
+
+        debug.field("pulse_width", &self.pulse_width());
+        debug.field("reserved_1", &self.reserved_1);
+        debug.field("vcp_sequencing_raw", &self.vcp_sequencing);
+        debug.field(
+            "vcp_sequencing_number_of_elevations",
+            &self.vcp_sequencing_number_of_elevations(),
+        );
+        debug.field(
+            "vcp_sequencing_maximum_sails_cuts",
+            &self.vcp_sequencing_maximum_sails_cuts(),
+        );
+        debug.field(
+            "vcp_sequencing_sequence_active",
+            &self.vcp_sequencing_sequence_active(),
+        );
+        debug.field(
+            "vcp_sequencing_truncated_vcp",
+            &self.vcp_sequencing_truncated_vcp(),
+        );
+        debug.field("vcp_supplemental_data_raw", &self.vcp_supplemental_data);
+        debug.field(
+            "vcp_supplemental_data_sails_vcp",
+            &self.vcp_supplemental_data_sails_vcp(),
+        );
+        debug.field(
+            "vcp_supplemental_data_number_sails_cuts",
+            &self.vcp_supplemental_data_number_sails_cuts(),
+        );
+        debug.field(
+            "vcp_supplemental_data_mrle_vcp",
+            &self.vcp_supplemental_data_mrle_vcp(),
+        );
+        debug.field(
+            "vcp_supplemental_data_number_mrle_cuts",
+            &self.vcp_supplemental_data_number_mrle_cuts(),
+        );
+        debug.field(
+            "vcp_supplemental_data_mpda_vcp",
+            &self.vcp_supplemental_data_mpda_vcp(),
+        );
+        debug.field(
+            "vcp_supplemental_data_base_tilt_vcp",
+            &self.vcp_supplemental_data_base_tilt_vcp(),
+        );
+        debug.field(
+            "vcp_supplemental_data_base_tilts",
+            &self.vcp_supplemental_data_base_tilts(),
+        );
+        debug.field("reserved_2", &self.reserved_2);
+
+        debug.finish()
     }
 }

--- a/nexrad-decode/src/messages/volume_coverage_pattern/header.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/header.rs
@@ -1,0 +1,83 @@
+use serde::Deserialize;
+
+use crate::messages::primitive_aliases::{
+    Code1, Code2, Integer1, Integer2, Integer4,
+};
+
+use std::fmt::Debug;
+
+/// The volume coverage pattern header block which contains information about the volume coverage pattern
+/// and the following data for each elevation
+#[derive(Clone, PartialEq, Deserialize)]
+pub struct Header {
+    /// Total message size in halfwords, including the header and all elevation blocks
+    pub message_size: Integer2,
+
+    /// Pattern type is always 2
+    pub pattern_type: Code2,
+
+    /// VCP Pattern Number
+    pub pattern_number: Integer2,
+
+    /// Number of elevation cuts in one complete volume scan
+    pub number_of_elevation_cuts: Integer2,
+
+    /// VCP version number
+    pub version: Integer1,
+
+    /// Clutter map groups are not currently implemented
+    pub clutter_map_group_number: Integer1,
+
+    /// Doppler velocity resolution.
+    /// 2 -> 0.5
+    /// 4 -> 1.0
+    pub doppler_velocity_resolution: Code1,
+
+    /// Pulse width values.
+    /// 2 -> Short
+    /// 4 -> Long
+    pub pulse_width: Code1,
+
+    /// Reserved
+    pub reserved_1: Integer4,
+
+    /// VCP sequencing values.
+    /// Bits 0-4: Number of Elevations
+    /// Bits 5-6: Maximum SAILS Cuts
+    /// Bit  13:  Sequence Active
+    /// Bit  14:  Truncated VCP
+    pub vcp_sequencing: Code2,
+
+    /// VCP supplemental data.
+    /// Bit  0:     SAILS VCP
+    /// Bits 1-3:   Number SAILS Cuts
+    /// Bit  4:     MRLE VCP
+    /// Bits 5-7:   Number MRLE Cuts
+    /// Bits 8-10:  Spare
+    /// Bit  11:    MPDA VCP
+    /// Bit  12:    BASE TILT VCP
+    /// Bits 13-15: Number of BASE TILTS
+    pub vcp_supplemental_data: Code2,
+
+    /// Reserved
+    pub reserved_2: Integer2,
+}
+
+impl Debug for Header {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Header")
+            .field("message_size", &self.message_size)
+            .field("pattern_type", &self.pattern_type)
+            .field("pattern_number", &self.pattern_number)
+            .field("number_of_elevation_cuts", &self.number_of_elevation_cuts)
+            .field("version", &self.version)
+            .field("clutter_map_group_number", &self.clutter_map_group_number)
+            .field("doppler_velocity_resolution", &self.doppler_velocity_resolution)
+            .field("pulse_width", &self.pulse_width)
+            .field("reserved_1", &self.reserved_1)
+            .field("vcp_sequencing", &self.vcp_sequencing)
+            .field("vcp_supplemental_data", &self.vcp_supplemental_data)
+            .field("reserved_2", &self.reserved_2)
+            .finish()
+    }
+}

--- a/nexrad-decode/src/messages/volume_coverage_pattern/message.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/message.rs
@@ -14,9 +14,6 @@ pub struct Message {
 impl Message {
     /// Create a new volume coverage pattern message
     pub(crate) fn new(header: Header, elevations: Vec<ElevationDataBlock>) -> Self {
-        Self {
-            header,
-            elevations,
-        }
+        Self { header, elevations }
     }
 }

--- a/nexrad-decode/src/messages/volume_coverage_pattern/message.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/message.rs
@@ -1,0 +1,22 @@
+use crate::messages::volume_coverage_pattern::{ElevationDataBlock, Header};
+
+/// The digital radar data message includes base radar data from a single radial for various
+/// products.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Message {
+    /// The decoded volume coverage pattern header.
+    pub header: Header,
+
+    /// The decoded elevation data blocks.
+    pub elevations: Vec<ElevationDataBlock>,
+}
+
+impl Message {
+    /// Create a new volume coverage pattern message
+    pub(crate) fn new(header: Header, elevations: Vec<ElevationDataBlock>) -> Self {
+        Self {
+            header,
+            elevations,
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Message type 5 (Volume Coverage Pattern) contains a lot of useful information for interpreting the individual elevation cuts.

## Solution

Decode it!

<details>
<summary>VCP message contents from `KDMX20240521_215236_V06`</summary>


NOTE: Angles are displayed in radians

```
Message {
    header: Header {
        message_size: 540,
        pattern_type: Constant,
        pattern_number: 212,
        number_of_elevation_cuts: 23,
        version: 1,
        clutter_map_group_number: 1,
        doppler_velocity_resolution: Some(
            0.5 m^1 s^-1,
        ),
        pulse_width: Short,
        reserved_1: 0,
        vcp_sequencing_raw: 0,
        vcp_sequencing_number_of_elevations: 0,
        vcp_sequencing_maximum_sails_cuts: 0,
        vcp_sequencing_sequence_active: false,
        vcp_sequencing_truncated_vcp: false,
        vcp_supplemental_data_raw: 112,
        vcp_supplemental_data_sails_vcp: false,
        vcp_supplemental_data_number_sails_cuts: 0,
        vcp_supplemental_data_mrle_vcp: true,
        vcp_supplemental_data_number_mrle_cuts: 3,
        vcp_supplemental_data_mpda_vcp: false,
        vcp_supplemental_data_base_tilt_vcp: false,
        vcp_supplemental_data_base_tilts: 0,
        reserved_2: 0,
    },
    elevations: [
        ElevationDataBlock {
            elevation_angle: 0.008436894333371027,
            channel_configuration: SZ2Phase,
            waveform_type: CS,
            super_resolution_control_raw: 11,
            super_resolution_control_half_degree_azimuth: true,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: false,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 1,
            surveillance_prf_pulse_count_radial: 15,
            azimuth_rate: 0.3691141270849824 s^-1,
            reflectivity_threshold: 2.0,
            velocity_threshold: 2.0,
            spectrum_width_threshold: 2.0,
            differential_reflectivity_threshold: 2.0,
            differential_phase_threshold: 2.0,
            correlation_coefficient_threshold: 2.0,
            sector_1_edge_angle: 0.0,
            sector_1_doppler_prf_number: 0,
            sector_1_doppler_prf_pulse_count_radial: 0,
            sector_2_edge_angle: 0.0,
            sector_2_doppler_prf_number: 0,
            sector_2_doppler_prf_pulse_count_radial: 0,
            sector_3_edge_angle: 0.0,
            sector_3_doppler_prf_number: 0,
            sector_3_doppler_prf_pulse_count_radial: 0,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.008436894333371027,
            channel_configuration: SZ2Phase,
            waveform_type: CDW,
            super_resolution_control_raw: 7,
            super_resolution_control_half_degree_azimuth: true,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: true,
            super_resolution_control_dual_polarization_to_300km: false,
            surveillance_prf_number: 0,
            surveillance_prf_pulse_count_radial: 0,
            azimuth_rate: 0.252339839607188 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 4,
            sector_1_doppler_prf_pulse_count_radial: 64,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 4,
            sector_2_doppler_prf_pulse_count_radial: 64,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 4,
            sector_3_doppler_prf_pulse_count_radial: 64,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.015339807878856412,
            channel_configuration: SZ2Phase,
            waveform_type: CS,
            super_resolution_control_raw: 11,
            super_resolution_control_half_degree_azimuth: true,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: false,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 1,
            surveillance_prf_pulse_count_radial: 15,
            azimuth_rate: 0.3691141270849824 s^-1,
            reflectivity_threshold: 2.0,
            velocity_threshold: 2.0,
            spectrum_width_threshold: 2.0,
            differential_reflectivity_threshold: 2.0,
            differential_phase_threshold: 2.0,
            correlation_coefficient_threshold: 2.0,
            sector_1_edge_angle: 0.0,
            sector_1_doppler_prf_number: 0,
            sector_1_doppler_prf_pulse_count_radial: 0,
            sector_2_edge_angle: 0.0,
            sector_2_doppler_prf_number: 0,
            sector_2_doppler_prf_pulse_count_radial: 0,
            sector_3_edge_angle: 0.0,
            sector_3_doppler_prf_number: 0,
            sector_3_doppler_prf_pulse_count_radial: 0,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.015339807878856412,
            channel_configuration: SZ2Phase,
            waveform_type: CDW,
            super_resolution_control_raw: 7,
            super_resolution_control_half_degree_azimuth: true,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: true,
            super_resolution_control_dual_polarization_to_300km: false,
            surveillance_prf_number: 0,
            surveillance_prf_pulse_count_radial: 0,
            azimuth_rate: 0.252339839607188 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 4,
            sector_1_doppler_prf_pulse_count_radial: 64,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 4,
            sector_2_doppler_prf_pulse_count_radial: 64,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 4,
            sector_3_doppler_prf_pulse_count_radial: 64,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.02300971181828462,
            channel_configuration: SZ2Phase,
            waveform_type: CS,
            super_resolution_control_raw: 11,
            super_resolution_control_half_degree_azimuth: true,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: false,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 2,
            surveillance_prf_pulse_count_radial: 15,
            azimuth_rate: 0.401902966426038 s^-1,
            reflectivity_threshold: 2.0,
            velocity_threshold: 2.0,
            spectrum_width_threshold: 2.0,
            differential_reflectivity_threshold: 2.0,
            differential_phase_threshold: 2.0,
            correlation_coefficient_threshold: 2.0,
            sector_1_edge_angle: 0.0,
            sector_1_doppler_prf_number: 0,
            sector_1_doppler_prf_pulse_count_radial: 0,
            sector_2_edge_angle: 0.0,
            sector_2_doppler_prf_number: 0,
            sector_2_doppler_prf_pulse_count_radial: 0,
            sector_3_edge_angle: 0.0,
            sector_3_doppler_prf_number: 0,
            sector_3_doppler_prf_pulse_count_radial: 0,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.02300971181828462,
            channel_configuration: SZ2Phase,
            waveform_type: CDW,
            super_resolution_control_raw: 7,
            super_resolution_control_half_degree_azimuth: true,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: true,
            super_resolution_control_dual_polarization_to_300km: false,
            surveillance_prf_number: 0,
            surveillance_prf_pulse_count_radial: 0,
            azimuth_rate: 0.252339839607188 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 4,
            sector_1_doppler_prf_pulse_count_radial: 64,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 4,
            sector_2_doppler_prf_pulse_count_radial: 64,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 4,
            sector_3_doppler_prf_pulse_count_radial: 64,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.03144660615165564,
            channel_configuration: ConstantPhase,
            waveform_type: B,
            super_resolution_control_raw: 14,
            super_resolution_control_half_degree_azimuth: false,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: true,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 3,
            surveillance_prf_pulse_count_radial: 3,
            azimuth_rate: 0.4605777315626638 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 4,
            sector_1_doppler_prf_pulse_count_radial: 26,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 4,
            sector_2_doppler_prf_pulse_count_radial: 26,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 4,
            sector_3_doppler_prf_pulse_count_radial: 26,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.042184471666855135,
            channel_configuration: ConstantPhase,
            waveform_type: B,
            super_resolution_control_raw: 14,
            super_resolution_control_half_degree_azimuth: false,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: true,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 4,
            surveillance_prf_pulse_count_radial: 3,
            azimuth_rate: 0.4770680250324344 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 4,
            sector_1_doppler_prf_pulse_count_radial: 26,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 4,
            sector_2_doppler_prf_pulse_count_radial: 26,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 4,
            sector_3_doppler_prf_pulse_count_radial: 26,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.054456317969940264,
            channel_configuration: ConstantPhase,
            waveform_type: B,
            super_resolution_control_raw: 14,
            super_resolution_control_half_degree_azimuth: false,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: true,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 5,
            surveillance_prf_pulse_count_radial: 3,
            azimuth_rate: 0.49259958050977654 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 4,
            sector_1_doppler_prf_pulse_count_radial: 26,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 4,
            sector_2_doppler_prf_pulse_count_radial: 26,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 4,
            sector_3_doppler_prf_pulse_count_radial: 26,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.06979612584879667,
            channel_configuration: ConstantPhase,
            waveform_type: B,
            super_resolution_control_raw: 14,
            super_resolution_control_half_degree_azimuth: false,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: true,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 6,
            surveillance_prf_pulse_count_radial: 3,
            azimuth_rate: 0.46076947916114946 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 4,
            sector_1_doppler_prf_pulse_count_radial: 27,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 4,
            sector_2_doppler_prf_pulse_count_radial: 27,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 4,
            sector_3_doppler_prf_pulse_count_radial: 27,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.08897088569736719,
            channel_configuration: ConstantPhase,
            waveform_type: B,
            super_resolution_control_raw: 14,
            super_resolution_control_half_degree_azimuth: false,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: true,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 6,
            surveillance_prf_pulse_count_radial: 3,
            azimuth_rate: 0.46076947916114946 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 4,
            sector_1_doppler_prf_pulse_count_radial: 28,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 4,
            sector_2_doppler_prf_pulse_count_radial: 28,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 4,
            sector_3_doppler_prf_pulse_count_radial: 28,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.008436894333371027,
            channel_configuration: SZ2Phase,
            waveform_type: CS,
            super_resolution_control_raw: 11,
            super_resolution_control_half_degree_azimuth: true,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: false,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 1,
            surveillance_prf_pulse_count_radial: 15,
            azimuth_rate: 0.3691141270849824 s^-1,
            reflectivity_threshold: 2.0,
            velocity_threshold: 2.0,
            spectrum_width_threshold: 2.0,
            differential_reflectivity_threshold: 2.0,
            differential_phase_threshold: 2.0,
            correlation_coefficient_threshold: 2.0,
            sector_1_edge_angle: 0.0,
            sector_1_doppler_prf_number: 0,
            sector_1_doppler_prf_pulse_count_radial: 0,
            sector_2_edge_angle: 0.0,
            sector_2_doppler_prf_number: 0,
            sector_2_doppler_prf_pulse_count_radial: 0,
            sector_3_edge_angle: 0.0,
            sector_3_doppler_prf_number: 0,
            sector_3_doppler_prf_pulse_count_radial: 0,
            ebc_angle: 0.0,
            supplemental_data: 48,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: true,
            supplemental_data_mrle_sequence_number: 1,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.008436894333371027,
            channel_configuration: SZ2Phase,
            waveform_type: CDW,
            super_resolution_control_raw: 7,
            super_resolution_control_half_degree_azimuth: true,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: true,
            super_resolution_control_dual_polarization_to_300km: false,
            surveillance_prf_number: 0,
            surveillance_prf_pulse_count_radial: 0,
            azimuth_rate: 0.252339839607188 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 4,
            sector_1_doppler_prf_pulse_count_radial: 64,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 4,
            sector_2_doppler_prf_pulse_count_radial: 64,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 4,
            sector_3_doppler_prf_pulse_count_radial: 64,
            ebc_angle: 0.0,
            supplemental_data: 48,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: true,
            supplemental_data_mrle_sequence_number: 1,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.015339807878856412,
            channel_configuration: SZ2Phase,
            waveform_type: CS,
            super_resolution_control_raw: 11,
            super_resolution_control_half_degree_azimuth: true,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: false,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 1,
            surveillance_prf_pulse_count_radial: 15,
            azimuth_rate: 0.3691141270849824 s^-1,
            reflectivity_threshold: 2.0,
            velocity_threshold: 2.0,
            spectrum_width_threshold: 2.0,
            differential_reflectivity_threshold: 2.0,
            differential_phase_threshold: 2.0,
            correlation_coefficient_threshold: 2.0,
            sector_1_edge_angle: 0.0,
            sector_1_doppler_prf_number: 0,
            sector_1_doppler_prf_pulse_count_radial: 0,
            sector_2_edge_angle: 0.0,
            sector_2_doppler_prf_number: 0,
            sector_2_doppler_prf_pulse_count_radial: 0,
            sector_3_edge_angle: 0.0,
            sector_3_doppler_prf_number: 0,
            sector_3_doppler_prf_pulse_count_radial: 0,
            ebc_angle: 0.0,
            supplemental_data: 80,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: true,
            supplemental_data_mrle_sequence_number: 2,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.015339807878856412,
            channel_configuration: SZ2Phase,
            waveform_type: CDW,
            super_resolution_control_raw: 7,
            super_resolution_control_half_degree_azimuth: true,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: true,
            super_resolution_control_dual_polarization_to_300km: false,
            surveillance_prf_number: 0,
            surveillance_prf_pulse_count_radial: 0,
            azimuth_rate: 0.252339839607188 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 4,
            sector_1_doppler_prf_pulse_count_radial: 64,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 4,
            sector_2_doppler_prf_pulse_count_radial: 64,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 4,
            sector_3_doppler_prf_pulse_count_radial: 64,
            ebc_angle: 0.0,
            supplemental_data: 80,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: true,
            supplemental_data_mrle_sequence_number: 2,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.02300971181828462,
            channel_configuration: SZ2Phase,
            waveform_type: CS,
            super_resolution_control_raw: 11,
            super_resolution_control_half_degree_azimuth: true,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: false,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 2,
            surveillance_prf_pulse_count_radial: 15,
            azimuth_rate: 0.401902966426038 s^-1,
            reflectivity_threshold: 2.0,
            velocity_threshold: 2.0,
            spectrum_width_threshold: 2.0,
            differential_reflectivity_threshold: 2.0,
            differential_phase_threshold: 2.0,
            correlation_coefficient_threshold: 2.0,
            sector_1_edge_angle: 0.0,
            sector_1_doppler_prf_number: 0,
            sector_1_doppler_prf_pulse_count_radial: 0,
            sector_2_edge_angle: 0.0,
            sector_2_doppler_prf_number: 0,
            sector_2_doppler_prf_pulse_count_radial: 0,
            sector_3_edge_angle: 0.0,
            sector_3_doppler_prf_number: 0,
            sector_3_doppler_prf_pulse_count_radial: 0,
            ebc_angle: 0.0,
            supplemental_data: 112,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: true,
            supplemental_data_mrle_sequence_number: 3,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.02300971181828462,
            channel_configuration: SZ2Phase,
            waveform_type: CDW,
            super_resolution_control_raw: 7,
            super_resolution_control_half_degree_azimuth: true,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: true,
            super_resolution_control_dual_polarization_to_300km: false,
            surveillance_prf_number: 0,
            surveillance_prf_pulse_count_radial: 0,
            azimuth_rate: 0.252339839607188 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 4,
            sector_1_doppler_prf_pulse_count_radial: 64,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 4,
            sector_2_doppler_prf_pulse_count_radial: 64,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 4,
            sector_3_doppler_prf_pulse_count_radial: 64,
            ebc_angle: 0.0,
            supplemental_data: 112,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: true,
            supplemental_data_mrle_sequence_number: 3,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.11198059751565181,
            channel_configuration: ConstantPhase,
            waveform_type: B,
            super_resolution_control_raw: 14,
            super_resolution_control_half_degree_azimuth: false,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: true,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 6,
            surveillance_prf_pulse_count_radial: 3,
            azimuth_rate: 0.46076947916114946 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 4,
            sector_1_doppler_prf_pulse_count_radial: 28,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 4,
            sector_2_doppler_prf_pulse_count_radial: 28,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 4,
            sector_3_doppler_prf_pulse_count_radial: 28,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.13959225169759334,
            channel_configuration: ConstantPhase,
            waveform_type: CDWO,
            super_resolution_control_raw: 10,
            super_resolution_control_half_degree_azimuth: false,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: false,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 0,
            surveillance_prf_pulse_count_radial: 0,
            azimuth_rate: 0.4960510372825192 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 6,
            sector_1_doppler_prf_pulse_count_radial: 38,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 6,
            sector_2_doppler_prf_pulse_count_radial: 38,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 6,
            sector_3_doppler_prf_pulse_count_radial: 38,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.1748738098189631,
            channel_configuration: ConstantPhase,
            waveform_type: CDWO,
            super_resolution_control_raw: 10,
            super_resolution_control_half_degree_azimuth: false,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: false,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 0,
            surveillance_prf_pulse_count_radial: 0,
            azimuth_rate: 0.49585928968403353 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 7,
            sector_1_doppler_prf_pulse_count_radial: 41,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 7,
            sector_2_doppler_prf_pulse_count_radial: 41,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 7,
            sector_3_doppler_prf_pulse_count_radial: 41,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.21782527187976106,
            channel_configuration: ConstantPhase,
            waveform_type: CDWO,
            super_resolution_control_raw: 10,
            super_resolution_control_half_degree_azimuth: false,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: false,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 0,
            surveillance_prf_pulse_count_radial: 0,
            azimuth_rate: 0.5016117176386047 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 8,
            sector_1_doppler_prf_pulse_count_radial: 44,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 8,
            sector_2_doppler_prf_pulse_count_radial: 44,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 8,
            sector_3_doppler_prf_pulse_count_radial: 44,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.2722815898497013,
            channel_configuration: ConstantPhase,
            waveform_type: CDWO,
            super_resolution_control_raw: 10,
            super_resolution_control_half_degree_azimuth: false,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: false,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 0,
            surveillance_prf_pulse_count_radial: 0,
            azimuth_rate: 0.5016117176386047 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 8,
            sector_1_doppler_prf_pulse_count_radial: 44,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 8,
            sector_2_doppler_prf_pulse_count_radial: 44,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 8,
            sector_3_doppler_prf_pulse_count_radial: 44,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
        ElevationDataBlock {
            elevation_angle: 0.34054373491061235,
            channel_configuration: ConstantPhase,
            waveform_type: CDWO,
            super_resolution_control_raw: 10,
            super_resolution_control_half_degree_azimuth: false,
            super_resolution_control_quarter_km_reflectivity: true,
            super_resolution_control_doppler_to_300km: false,
            super_resolution_control_dual_polarization_to_300km: true,
            surveillance_prf_number: 0,
            surveillance_prf_pulse_count_radial: 0,
            azimuth_rate: 0.5016117176386047 s^-1,
            reflectivity_threshold: 3.5,
            velocity_threshold: 3.5,
            spectrum_width_threshold: 3.5,
            differential_reflectivity_threshold: 3.5,
            differential_phase_threshold: 3.5,
            correlation_coefficient_threshold: 3.5,
            sector_1_edge_angle: 0.5238544390629465,
            sector_1_doppler_prf_number: 8,
            sector_1_doppler_prf_pulse_count_radial: 44,
            sector_2_edge_angle: 3.6654470926527396,
            sector_2_doppler_prf_number: 8,
            sector_2_doppler_prf_pulse_count_radial: 44,
            sector_3_edge_angle: 5.846767773026121,
            sector_3_doppler_prf_number: 8,
            sector_3_doppler_prf_pulse_count_radial: 44,
            ebc_angle: 0.0,
            supplemental_data: 0,
            supplemental_data_sails_cut: false,
            supplemental_data_sails_sequence_number: 0,
            supplemental_data_mrle_cut: false,
            supplemental_data_mrle_sequence_number: 0,
            supplemental_data_mpda_cut: false,
            supplemental_data_base_tilt_cut: false,
            reserved: 0,
        },
    ],
}
```

</details>