### PR TITLE
Encapsulate and rename message structures

### DIFF
--- a/nexrad-data/src/volume/file.rs
+++ b/nexrad-data/src/volume/file.rs
@@ -33,7 +33,7 @@ impl File {
     #[cfg(all(feature = "nexrad-model", feature = "decode"))]
     pub fn scan(&self) -> Result<nexrad_model::data::Scan> {
         use crate::result::Error;
-        use nexrad_decode::messages::Message;
+        use nexrad_decode::messages::MessageContents;
         use nexrad_model::data::{Scan, Sweep};
 
         let mut coverage_pattern_number = None;
@@ -45,7 +45,7 @@ impl File {
 
             let messages = record.messages()?;
             for message in messages {
-                if let Message::DigitalRadarData(radar_data_message) = message.message {
+                if let MessageContents::DigitalRadarData(radar_data_message) = message.contents {
                     if coverage_pattern_number.is_none() {
                         if let Some(volume_block) = &radar_data_message.volume_data_block {
                             coverage_pattern_number =

--- a/nexrad-data/src/volume/file.rs
+++ b/nexrad-data/src/volume/file.rs
@@ -45,7 +45,8 @@ impl File {
 
             let messages = record.messages()?;
             for message in messages {
-                if let MessageContents::DigitalRadarData(radar_data_message) = message.contents {
+                let contents = message.into_contents();
+                if let MessageContents::DigitalRadarData(radar_data_message) = contents {
                     if coverage_pattern_number.is_none() {
                         if let Some(volume_block) = &radar_data_message.volume_data_block {
                             coverage_pattern_number =

--- a/nexrad-data/src/volume/record.rs
+++ b/nexrad-data/src/volume/record.rs
@@ -70,9 +70,7 @@ impl<'a> Record<'a> {
 
     /// Decodes the NEXRAD level II messages contained in this LDM record.
     #[cfg(feature = "decode")]
-    pub fn messages(
-        &self,
-    ) -> crate::result::Result<Vec<nexrad_decode::messages::MessageWithHeader>> {
+    pub fn messages(&self) -> crate::result::Result<Vec<nexrad_decode::messages::Message>> {
         use crate::result::Error;
         use nexrad_decode::messages::decode_messages;
         use std::io::Cursor;

--- a/nexrad-decode/src/messages.rs
+++ b/nexrad-decode/src/messages.rs
@@ -33,11 +33,8 @@ pub fn decode_messages<R: Read + Seek>(reader: &mut R) -> Result<Vec<Message>> {
 
     let mut messages = Vec::new();
     while let Ok(header) = decode_message_header(reader) {
-        let message = decode_message_contents(reader, header.message_type())?;
-        messages.push(Message {
-            header,
-            contents: message,
-        });
+        let contents = decode_message_contents(reader, header.message_type())?;
+        messages.push(Message::unsegmented(header, contents));
     }
 
     debug!(

--- a/nexrad-decode/src/messages.rs
+++ b/nexrad-decode/src/messages.rs
@@ -8,7 +8,7 @@ mod message_type;
 pub use message_type::MessageType;
 
 mod message;
-pub use message::{Message, MessageWithHeader};
+pub use message::{Message, MessageContents};
 
 mod definitions;
 mod primitive_aliases;
@@ -28,13 +28,16 @@ pub fn decode_message_header<R: Read>(reader: &mut R) -> Result<MessageHeader> {
 }
 
 /// Decode a series of NEXRAD Level II messages from a reader.
-pub fn decode_messages<R: Read + Seek>(reader: &mut R) -> Result<Vec<MessageWithHeader>> {
+pub fn decode_messages<R: Read + Seek>(reader: &mut R) -> Result<Vec<Message>> {
     debug!("Decoding messages");
 
     let mut messages = Vec::new();
     while let Ok(header) = decode_message_header(reader) {
-        let message = decode_message(reader, header.message_type())?;
-        messages.push(MessageWithHeader { header, message });
+        let message = decode_message_contents(reader, header.message_type())?;
+        messages.push(Message {
+            header,
+            contents: message,
+        });
     }
 
     debug!(
@@ -46,34 +49,36 @@ pub fn decode_messages<R: Read + Seek>(reader: &mut R) -> Result<Vec<MessageWith
     Ok(messages)
 }
 
-/// Decode a NEXRAD Level II message of the specified type from a reader.
-pub fn decode_message<R: Read + Seek>(
+/// Decode the content of a NEXRAD Level II message of the specified type from a reader.
+pub fn decode_message_contents<R: Read + Seek>(
     reader: &mut R,
     message_type: MessageType,
-) -> Result<Message> {
+) -> Result<MessageContents> {
     let position = reader.stream_position();
     trace!("Decoding message type {:?} at {:?}", message_type, position);
 
     if message_type == MessageType::RDADigitalRadarDataGenericFormat {
-        let decoded_message = decode_digital_radar_data(reader)?;
-        return Ok(Message::DigitalRadarData(Box::new(decoded_message)));
+        let radar_data_message = decode_digital_radar_data(reader)?;
+        return Ok(MessageContents::DigitalRadarData(Box::new(
+            radar_data_message,
+        )));
     }
 
     let mut message_buffer = [0; 2432 - size_of::<MessageHeader>()];
     reader.read_exact(&mut message_buffer)?;
 
-    let message_reader = &mut message_buffer.as_ref();
+    let contents_reader = &mut message_buffer.as_ref();
     Ok(match message_type {
         MessageType::RDAStatusData => {
-            Message::RDAStatusData(Box::new(decode_rda_status_message(message_reader)?))
+            MessageContents::RDAStatusData(Box::new(decode_rda_status_message(contents_reader)?))
         }
-        MessageType::RDAVolumeCoveragePattern => Message::VolumeCoveragePattern(Box::new(
-            decode_volume_coverage_pattern(message_reader)?,
+        MessageType::RDAVolumeCoveragePattern => MessageContents::VolumeCoveragePattern(Box::new(
+            decode_volume_coverage_pattern(contents_reader)?,
         )),
         // TODO: this message type is segmented which is not supported well currently
         // MessageType::RDAClutterFilterMap => {
         //     Message::ClutterFilterMap(Box::new(decode_clutter_filter_map(message_reader)?))
         // }
-        _ => Message::Other,
+        _ => MessageContents::Other,
     })
 }

--- a/nexrad-decode/src/messages/message.rs
+++ b/nexrad-decode/src/messages/message.rs
@@ -39,9 +39,24 @@ impl Message {
 /// A decoded NEXRAD Level II message's contents.
 #[derive(Debug, Clone, PartialEq)]
 pub enum MessageContents {
+    /// Message type 2 "RDA Status Data" contains information about the current RDA state, system
+    /// control, operating status, scanning strategy, performance parameters like transmitter power
+    /// and calibration, and system alarms
     RDAStatusData(Box<rda_status_data::Message>),
+
+    /// Message type 31 "Digital Radar Data" consists of base data information such as reflectivity,
+    /// mean radial velocity, spectrum width, differential reflectivity, differential phase,
+    /// correlation coefficient, azimuth angle, elevation angle, cut type, scanning strategy, and
+    /// calibration parameters.
     DigitalRadarData(Box<digital_radar_data::Message>),
+
+    /// Message type 15 "Clutter Filter Map" contains information about clutter filter maps that are
+    /// used to filter clutter from radar products
     ClutterFilterMap(Box<clutter_filter_map::Message>),
+
+    /// Message type 5 "Volume Coverage Pattern" provides details about the volume
+    /// coverage pattern being used, including detailed settings for each elevation.
     VolumeCoveragePattern(Box<volume_coverage_pattern::Message>),
+    
     Other,
 }

--- a/nexrad-decode/src/messages/message.rs
+++ b/nexrad-decode/src/messages/message.rs
@@ -14,12 +14,9 @@ pub struct Message {
 impl Message {
     /// Create a new unsegmented message.
     pub(crate) fn unsegmented(header: MessageHeader, contents: MessageContents) -> Self {
-        Self {
-            header,
-            contents,
-        }
+        Self { header, contents }
     }
-    
+
     /// This message's header.
     pub fn header(&self) -> &MessageHeader {
         &self.header
@@ -57,6 +54,6 @@ pub enum MessageContents {
     /// Message type 5 "Volume Coverage Pattern" provides details about the volume
     /// coverage pattern being used, including detailed settings for each elevation.
     VolumeCoveragePattern(Box<volume_coverage_pattern::Message>),
-    
+
     Other,
 }

--- a/nexrad-decode/src/messages/message.rs
+++ b/nexrad-decode/src/messages/message.rs
@@ -6,14 +6,14 @@ use crate::messages::volume_coverage_pattern;
 
 /// A decoded NEXRAD Level II message with its metadata header.
 #[derive(Debug, Clone, PartialEq)]
-pub struct MessageWithHeader {
+pub struct Message {
     pub header: MessageHeader,
-    pub message: Message,
+    pub contents: MessageContents,
 }
 
-/// A decoded NEXRAD Level II message.
+/// A decoded NEXRAD Level II message's contents.
 #[derive(Debug, Clone, PartialEq)]
-pub enum Message {
+pub enum MessageContents {
     RDAStatusData(Box<rda_status_data::Message>),
     DigitalRadarData(Box<digital_radar_data::Message>),
     ClutterFilterMap(Box<clutter_filter_map::Message>),

--- a/nexrad-decode/src/messages/message.rs
+++ b/nexrad-decode/src/messages/message.rs
@@ -7,8 +7,33 @@ use crate::messages::volume_coverage_pattern;
 /// A decoded NEXRAD Level II message with its metadata header.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Message {
-    pub header: MessageHeader,
-    pub contents: MessageContents,
+    header: MessageHeader,
+    contents: MessageContents,
+}
+
+impl Message {
+    /// Create a new unsegmented message.
+    pub(crate) fn unsegmented(header: MessageHeader, contents: MessageContents) -> Self {
+        Self {
+            header,
+            contents,
+        }
+    }
+    
+    /// This message's header.
+    pub fn header(&self) -> &MessageHeader {
+        &self.header
+    }
+
+    /// This message's contents.
+    pub fn contents(&self) -> &MessageContents {
+        &self.contents
+    }
+
+    /// Consume this message, returning ownership of its contents.
+    pub fn into_contents(self) -> MessageContents {
+        self.contents
+    }
 }
 
 /// A decoded NEXRAD Level II message's contents.

--- a/nexrad-decode/src/summarize.rs
+++ b/nexrad-decode/src/summarize.rs
@@ -88,7 +88,7 @@ pub fn messages(messages: &[Message]) -> MessageSummary {
     };
 
     if let Some(first_message) = messages.first() {
-        summary.earliest_collection_time = first_message.header.date_time();
+        summary.earliest_collection_time = first_message.header().date_time();
     }
 
     let mut scan_summary = None;
@@ -108,7 +108,7 @@ fn process_message(
     scan_summary: &mut Option<ScanSummary>,
     message: &Message,
 ) {
-    let message_type = message.header.message_type();
+    let message_type = message.header().message_type();
     if let Some((last_message_type, count)) = summary.message_types.last_mut() {
         if *last_message_type == message_type {
             *count += 1;
@@ -119,7 +119,7 @@ fn process_message(
         summary.message_types.push((message_type, 1));
     }
 
-    match &message.contents {
+    match message.contents() {
         MessageContents::DigitalRadarData(radar_data_message) => {
             process_digital_radar_data_message(summary, scan_summary, radar_data_message);
             return;


### PR DESCRIPTION
Some minor renaming and field-encapsulation of the `Message` type before adding support for segmented messages.

**BREAKING**:
- `MessageWithHeader` renamed to `Message`
- `Message` renamed to `MessageContents`
- The `header` and `body` fields are now readable via `header()` and `contents()` getters
- Construction of `Message` is no longer public/exposed