### PR TITLE
Include rustls feature in reqwest to avoid openssl dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ uom = { version = "0.36" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { version = "1.0" }
 bincode = { version = "1.3" }
-reqwest = { version = "0.12" }
+reqwest = { version = "0.12", features = ["rustls-tls"]}
 xml = { version = "0.8" }
 bzip2 = { version = "0.4" }
 bzip2-rs = { version = "0.1" }


### PR DESCRIPTION
Reqwest uses [native_tls](https://docs.rs/native-tls/latest/native_tls/) by default, which is platform specific, however for linux the default is openssl (on linux) which is less preferable for build/deploy reasons than the pure-rust tls impl provided by rustls.

This should be completely invisible to users, the only case I can think of where behavior may change is in the root tls store, but in this crate's case the only endpoint requested is aws.