### PR TITLE
Fully remove openssl dependency from reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ uom = { version = "0.36" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { version = "1.0" }
 bincode = { version = "1.3" }
-reqwest = { version = "0.12", features = ["rustls-tls"]}
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 xml = { version = "0.8" }
 bzip2 = { version = "0.4" }
 bzip2-rs = { version = "0.1" }


### PR DESCRIPTION
Even after https://github.com/danielway/nexrad/pull/20 was merged, `openssl` is still in the package tree and attempts to build on linux. This can be seen by running `cargo tree -i openssl --target all`. I believe this is because `reqwest` still includes `native-tls` by default.

By setting `default-features = false` we can fully remove the `openssl` dependency.

Both the realtime and archive example apps still work so I believe there were no default dependencies needed by the project that are now excluded.