### PR TITLE
Add elevation angles export example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,6 @@ xml = { version = "0.8" }
 bzip2 = { version = "0.4" }
 bzip2-rs = { version = "0.1" }
 rayon = { version = "1.10" }
-tokio = { version = "1" }
+tokio = { version = "1", features = ["full"] }
+env_logger = { version = "0.11" }
+nexrad-data = { version = "0.2.0", path = "./nexrad-data" }

--- a/nexrad-data/Cargo.toml
+++ b/nexrad-data/Cargo.toml
@@ -21,11 +21,19 @@ bincode = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 xml = { workspace = true, optional = true }
 bzip2 = { workspace = true, optional = true }
-clap = { workspace = true }
 tokio = { workspace = true, optional = true }
 nexrad-model = { version = "0.1.0", path = "../nexrad-model", optional = true }
 nexrad-decode = { version = "0.1.1", path = "../nexrad-decode", optional = true }
 
 [dev-dependencies]
-env_logger = { version = "0.11" }
-tokio = { version = "1", features = ["full"] }
+clap = { workspace = true }
+env_logger = { workspace = true }
+tokio = { workspace = true }
+
+[[example]]
+name = "realtime"
+path = "examples/realtime.rs"
+
+[[example]]
+name = "archive"
+path = "examples/archive.rs"

--- a/nexrad-decode/Cargo.toml
+++ b/nexrad-decode/Cargo.toml
@@ -18,3 +18,13 @@ serde = { workspace = true }
 chrono = { workspace = true }
 nexrad-model = { version = "0.1.0", path = "../nexrad-model", optional = true }
 uom = { workspace = true, optional = true }
+
+[dev-dependencies]
+clap = { workspace = true }
+env_logger = { workspace = true }
+tokio = { workspace = true }
+nexrad-data = { workspace = true }
+
+[[example]]
+name = "elevation_angles"
+path = "examples/elevation_angles.rs"

--- a/nexrad-decode/examples/README.md
+++ b/nexrad-decode/examples/README.md
@@ -1,0 +1,34 @@
+# NEXRAD Decode Examples
+
+This directory contains examples demonstrating how to use the `nexrad-decode` library for working with NEXRAD weather radar data.
+
+## Available Examples
+
+### Elevation Angles CSV Generator
+
+The `elevation_angles.rs` example demonstrates how to extract elevation angle data from a NEXRAD Archive II file and generate a CSV file. 
+The CSV has:
+- Columns representing elevation numbers (elev_1, elev_2, etc.)
+- Rows representing azimuth numbers
+- Values at the intersection representing the elevation angle for that elevation/azimuth number combination
+
+#### Usage
+
+```bash
+# Run with default output filename (elevation_angles.csv)
+cargo run --example elevation_angles -- /path/to/archive_file.ar2
+
+# Specify a custom output filename
+cargo run --example elevation_angles -- /path/to/archive_file.ar2 --output-path custom_output.csv
+```
+
+#### Example Output Format
+
+```
+azimuth_num,elev_1,elev_2,elev_3
+1,0.52,1.45,2.41
+2,0.52,1.46,2.40
+...
+```
+
+Note: Empty cells in the CSV indicate that no data was available for that particular elevation/azimuth number combination. 

--- a/nexrad-decode/examples/elevation_angles.rs
+++ b/nexrad-decode/examples/elevation_angles.rs
@@ -1,0 +1,125 @@
+use clap::Parser;
+use log::{debug, info, LevelFilter};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{Read, Write};
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    /// Path to the Archive II file to process
+    #[arg(required = true)]
+    file_path: String,
+
+    /// Path to save the output CSV file (defaults to 'elevation_angles.csv')
+    #[arg(default_value = "elevation_angles.csv")]
+    output_path: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize logging
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .filter_module("reqwest::connect", LevelFilter::Info)
+        .init();
+
+    // Parse command line arguments
+    let cli = Cli::parse();
+    let file_path = &cli.file_path;
+    let output_path = &cli.output_path;
+
+    info!("Processing file: {}", file_path);
+
+    // Read the file
+    let mut file = File::open(file_path).expect(&format!("Failed to open file: {}", file_path));
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer)?;
+
+    // Parse the Archive II file
+    let volume_file = nexrad_data::volume::File::new(buffer);
+
+    // Create a HashMap to store elevation angles by elevation and azimuth numbers
+    // Key: (elevation_number, azimuth_number), Value: elevation_angle
+    let mut elevation_angles: HashMap<(u8, u16), f32> = HashMap::new();
+
+    // Maximum elevation number and azimuth number for CSV dimensions
+    let mut max_elevation_num = 0;
+    let mut max_azimuth_num = 0;
+
+    // Process all records in the file
+    for mut record in volume_file.records() {
+        debug!("Processing record...");
+        if record.compressed() {
+            debug!("Decompressing LDM record...");
+            record = record.decompress().expect("Failed to decompress record");
+        }
+
+        // Extract messages from the record
+        let messages = record.messages()?;
+
+        // Process each message to extract elevation angles
+        for message in messages {
+            // Check if the message is a Digital Radar Data message
+            if let nexrad_decode::messages::MessageContents::DigitalRadarData(digital_data) =
+                message.contents()
+            {
+                // Access header information where the elevation data is stored
+                let header = &digital_data.header;
+
+                let elevation_num = header.elevation_number;
+                let azimuth_num = header.azimuth_number;
+                let elevation_angle = header.elevation_angle;
+
+                // Update max values for dimensions
+                if elevation_num > max_elevation_num {
+                    max_elevation_num = elevation_num;
+                }
+                if azimuth_num > max_azimuth_num {
+                    max_azimuth_num = azimuth_num;
+                }
+
+                // Store elevation angle information
+                elevation_angles.insert((elevation_num, azimuth_num), elevation_angle);
+                debug!(
+                    "Elevation: {}, Azimuth Number: {}, Elevation Angle: {}",
+                    elevation_num, azimuth_num, elevation_angle
+                );
+            }
+        }
+    }
+
+    info!(
+        "Found elevation angles for {} elevation-azimuth combinations",
+        elevation_angles.len()
+    );
+    info!("Maximum elevation number: {}", max_elevation_num);
+    info!("Maximum azimuth number: {}", max_azimuth_num);
+
+    // Create and write the CSV file
+    let mut output_file = File::create(output_path)?;
+
+    // Write header with elevation numbers
+    write!(output_file, "azimuth_num")?;
+    for elev in 1..=max_elevation_num {
+        write!(output_file, ",elev_{}", elev)?;
+    }
+    writeln!(output_file)?;
+
+    // Write rows for each azimuth number
+    for azimuth_num in 1..=max_azimuth_num {
+        write!(output_file, "{}", azimuth_num)?;
+
+        // For each elevation in this azimuth number, write the elevation angle
+        for elev_num in 1..=max_elevation_num {
+            match elevation_angles.get(&(elev_num, azimuth_num)) {
+                Some(angle) => write!(output_file, ",{:.2}", angle)?,
+                None => write!(output_file, ",")?, // Empty value if no data for this combination
+            }
+        }
+        writeln!(output_file)?;
+    }
+
+    info!("CSV file created successfully: {}", output_path);
+
+    Ok(())
+}


### PR DESCRIPTION
## Overview
This PR adds a new example script to the `nexrad-decode` crate that demonstrates how to extract elevation angle data from NEXRAD Archive II files and generate a CSV dataset.

I added this script to answer a curiosity I had about how precisely the radar maintains its target angles, particularly when transitioning between sweeps. Here is a plot of that data with elevation angle for the y-axis, azimuth number for the x-axis, and elevation numbers/sweeps as series. You can clearly see the instrument "over-shoot" its target elevation at the start of each sweep.

<img width="623" alt="image" src="https://github.com/user-attachments/assets/fc35c456-6e9c-464b-82d8-d919ab211483" />

_Radar elevations from a scan at KDMX: `KDMX20220305_232324_V06`._

## Implementation Details
The new `elevation_angles.rs` example:
- Processes a NEXRAD Archive II file specified via command-line argument
- Extracts elevation angle data for each combination of elevation number and azimuth number from Digital Radar Data messages
- Generates a CSV file where:
  - Columns represent elevation numbers (elev_1, elev_2, etc.)
  - Rows represent azimuth numbers
  - Values at the intersection represent the elevation angle for that combination

## Features
- Simple command-line interface with clap for parsing arguments
- Comprehensive error handling using Rust's Result type
- Configurable output path (defaults to `elevation_angles.csv`)
- Informative logging at various levels through the env_logger crate
- Generates a clean, well-formatted CSV output for further analysis

## Example Usage
```bash
# Run with default output file name
cargo run --example elevation_angles -- /path/to/archive_file.ar2

# Specify a custom output file name
cargo run --example elevation_angles -- /path/to/archive_file.ar2 --output-path custom_output.csv
```

## Documentation
- Added documentation within the code explaining each step of the process
- Updated examples/README.md with usage instructions and example output format

## Related Work
This example follows a similar structure to the existing examples in the `nexrad-data` crate, providing a consistent approach across the project.
