### PR TITLE
Improve message summarization

### DIFF
--- a/nexrad-data/examples/archive.rs
+++ b/nexrad-data/examples/archive.rs
@@ -130,7 +130,7 @@ async fn main() -> nexrad_data::result::Result<()> {
         }
 
         let summary = nexrad_decode::summarize::messages(messages.as_slice());
-        info!("Volume summary:\n{:#?}", summary);
+        info!("Volume summary:\n{}", summary);
     }
 
     Ok(())

--- a/nexrad-data/examples/archive.rs
+++ b/nexrad-data/examples/archive.rs
@@ -79,6 +79,11 @@ async fn main() -> nexrad_data::result::Result<()> {
         .skip(start_index)
         .take(stop_index - start_index + 1)
     {
+        if file_id.name().ends_with("_MDM") {
+            debug!("Skipping MDM file: {}", file_id.name());
+            continue;
+        }
+
         let file = if Path::new(&format!("downloads/{}", file_id.name())).exists() {
             debug!("File \"{}\" already downloaded.", file_id.name());
             let mut file =

--- a/nexrad-data/examples/archive.rs
+++ b/nexrad-data/examples/archive.rs
@@ -118,9 +118,9 @@ async fn main() -> nexrad_data::result::Result<()> {
             file.header()
         );
 
+        debug!("Decoding {} records...", records.len());
         let mut messages = Vec::new();
         for mut record in records {
-            debug!("Decoding record...");
             if record.compressed() {
                 trace!("Decompressing LDM record...");
                 record = record.decompress().expect("Failed to decompress record");

--- a/nexrad-data/examples/realtime.rs
+++ b/nexrad-data/examples/realtime.rs
@@ -164,7 +164,7 @@ fn decode_record(
 
     let messages = record.messages().expect("Failed to decode messages");
     let summary = nexrad_decode::summarize::messages(messages.as_slice());
-    info!("Record summary:\n{:#?}", summary);
+    info!("Record summary:\n{}", summary);
 
     info!(
         "Message latency: {:?}",

--- a/nexrad-decode/src/messages.rs
+++ b/nexrad-decode/src/messages.rs
@@ -19,7 +19,7 @@ use crate::messages::rda_status_data::decode_rda_status_message;
 use crate::messages::volume_coverage_pattern::decode_volume_coverage_pattern;
 use crate::result::Result;
 use crate::util::deserialize;
-use log::{debug, trace};
+use log::trace;
 use std::io::{Read, Seek};
 
 /// Decode a NEXRAD Level II message from a reader.
@@ -29,7 +29,7 @@ pub fn decode_message_header<R: Read>(reader: &mut R) -> Result<MessageHeader> {
 
 /// Decode a series of NEXRAD Level II messages from a reader.
 pub fn decode_messages<R: Read + Seek>(reader: &mut R) -> Result<Vec<Message>> {
-    debug!("Decoding messages");
+    trace!("Decoding messages");
 
     let mut messages = Vec::new();
     while let Ok(header) = decode_message_header(reader) {
@@ -37,7 +37,7 @@ pub fn decode_messages<R: Read + Seek>(reader: &mut R) -> Result<Vec<Message>> {
         messages.push(Message::unsegmented(header, contents));
     }
 
-    debug!(
+    trace!(
         "Decoded {} messages ending at {:?}",
         messages.len(),
         reader.stream_position()

--- a/nexrad-decode/src/messages/message_header.rs
+++ b/nexrad-decode/src/messages/message_header.rs
@@ -126,7 +126,7 @@ impl MessageHeader {
             31 => MessageType::RDADigitalRadarDataGenericFormat,
             32 => MessageType::RDAPRFData,
             33 => MessageType::RDALogData,
-            _ => MessageType::Unknown,
+            _ => MessageType::Unknown(self.message_type),
         }
     }
 

--- a/nexrad-decode/src/messages/message_type.rs
+++ b/nexrad-decode/src/messages/message_type.rs
@@ -1,5 +1,6 @@
 /// The types of data messages transferred between the RDA and RPG.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Ord, PartialOrd)]
+#[repr(u8)]
 pub enum MessageType {
     /// Replaced by message type 31.
     RDADigitalRadarData = 1,
@@ -66,5 +67,5 @@ pub enum MessageType {
 
     RDALogData = 33,
 
-    Unknown,
+    Unknown(u8),
 }

--- a/nexrad-decode/src/summarize.rs
+++ b/nexrad-decode/src/summarize.rs
@@ -109,11 +109,25 @@ impl Display for ScanSummary {
             writeln!(f, "")?;
             write!(f, "    Data types: ")?;
             let data_types: Vec<_> = self.data_types.iter().collect();
+            
             for (i, (data_type, count)) in data_types.iter().enumerate() {
                 if i > 0 {
                     write!(f, ", ")?;
                 }
-                write!(f, "{} ({})", data_type, count)?;
+                
+                // Use abbreviated names for common data types
+                let abbr = match data_type.as_str() {
+                    "Reflectivity" => "REF",
+                    "Velocity" => "VEL",
+                    "Spectrum Width" => "SW",
+                    "Differential Reflectivity" => "ZDR",
+                    "Differential Phase" => "DP",
+                    "Correlation Coefficient" => "CC",
+                    "Specific Differential Phase" => "KDP",
+                    _ => data_type, // Keep other names unchanged
+                };
+                
+                write!(f, "{} ({})", abbr, count)?;
             }
         }
         

--- a/nexrad-decode/src/summarize.rs
+++ b/nexrad-decode/src/summarize.rs
@@ -161,11 +161,6 @@ fn process_message(
 
     if let MessageContents::DigitalRadarData(radar_data_message) = message.contents() {
         process_digital_radar_data_message(summary, scan_summary, radar_data_message);
-        return;
-    }
-
-    if let Some(scan_summary) = scan_summary.take() {
-        summary.scans.push(scan_summary);
     }
 }
 

--- a/nexrad-decode/src/summarize.rs
+++ b/nexrad-decode/src/summarize.rs
@@ -31,10 +31,15 @@ impl Display for MessageSummary {
         }
         
         if let Some(end) = self.latest_collection_time {
-            writeln!(f, ", End: {}", end.format("%Y-%m-%d %H:%M:%S%.3f UTC"))?;
+            write!(f, ", End: {}", end.format("%Y-%m-%d %H:%M:%S%.3f UTC"))?;
+            if let Some(start) = self.earliest_collection_time {
+                let duration = end.signed_duration_since(start);
+                write!(f, " ({:.2}m)", duration.num_milliseconds() as f64 / 60000.0)?;
+            }
         } else {
-            writeln!(f, ", End: unknown")?;
+            write!(f, ", End: unknown")?;
         }
+        writeln!(f)?;
         
         // Volume coverage patterns
         write!(f, "VCPs: ")?;
@@ -101,6 +106,8 @@ impl Display for ScanSummary {
             if let Some(end) = self.end_time {
                 if start != end {
                     write!(f, " to {}", end.format("%H:%M:%S%.3f"))?;
+                    let duration = end.signed_duration_since(start);
+                    write!(f, " ({:.2}s)", duration.num_milliseconds() as f64 / 1000.0)?;
                 }
             }
         }

--- a/nexrad-decode/src/summarize.rs
+++ b/nexrad-decode/src/summarize.rs
@@ -13,22 +13,6 @@
 //! * Logical groupings of related messages
 //! * Time range of the data collection
 //! * Detailed information about radar status, scan strategies, and data types
-//!
-//! ## Usage Example
-//!
-//! ```rust
-//! use nexrad_decode::messages::Message;
-//! use nexrad_decode::summarize;
-//!
-//! // Assuming you have parsed messages from a NEXRAD file
-//! let messages: Vec<Message> = /* ... */;
-//!
-//! // Generate a summary
-//! let summary = summarize::messages(&messages);
-//!
-//! // Print the summary
-//! println!("{}", summary);
-//! ```
 
 use crate::messages::{Message, MessageContents, MessageType};
 use std::collections::{HashMap, HashSet};

--- a/nexrad-decode/src/summarize.rs
+++ b/nexrad-decode/src/summarize.rs
@@ -20,20 +20,22 @@ pub struct MessageSummary {
 impl Display for MessageSummary {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         // Time information
+        write!(f, "Scans from ")?;
         if let Some(start) = self.earliest_collection_time {
-            write!(f, "Start: {}", start.format("%Y-%m-%d %H:%M:%S%.3f UTC"))?;
+            write!(f, "{}", start.format("%Y-%m-%d %H:%M:%S%.3f UTC"))?;
         } else {
-            write!(f, "Start: unknown")?;
+            write!(f, "unknown")?;
         }
 
+        write!(f, " to ")?;
         if let Some(end) = self.latest_collection_time {
-            write!(f, ", End: {}", end.format("%Y-%m-%d %H:%M:%S%.3f UTC"))?;
+            write!(f, "{}", end.format("%Y-%m-%d %H:%M:%S%.3f UTC"))?;
             if let Some(start) = self.earliest_collection_time {
                 let duration = end.signed_duration_since(start);
                 write!(f, " ({:.2}m)", duration.num_milliseconds() as f64 / 60000.0)?;
             }
         } else {
-            write!(f, ", End: unknown")?;
+            write!(f, "unknown")?;
         }
         writeln!(f)?;
 
@@ -171,10 +173,10 @@ impl Display for MessageGroupSummary {
                 write!(f, " ({})", self.message_count)?;
             }
             if let Some(start) = self.start_time {
-                write!(f, ", Time: {}", start.format("%H:%M:%S%.3f"))?;
+                write!(f, ", Time: {}", start.format("%Y-%m-%d %H:%M:%S%.3f"))?;
                 if let Some(end) = self.end_time {
                     if start != end {
-                        write!(f, " to {}", end.format("%H:%M:%S%.3f"))?;
+                        write!(f, " to {}", end.format("%Y-%m-%d %H:%M:%S%.3f"))?;
                     }
                 }
             }

--- a/nexrad-decode/src/summarize.rs
+++ b/nexrad-decode/src/summarize.rs
@@ -1,563 +1,69 @@
-use crate::messages::digital_radar_data;
+//! # Summarize Module
+//!
+//! The `summarize` module provides functionality for generating human-readable summaries
+//! of NEXRAD radar data messages. It processes raw radar messages and organizes them into
+//! logical groups based on their type and content, making it easier to understand the
+//! structure and content of radar data files.
+//!
+//! The primary function in this module is `messages()`, which takes a slice of `Message` objects
+//! and returns a `MessageSummary` containing organized information about those messages.
+//! The summary includes:
+//!
+//! * Volume coverage patterns found in the messages
+//! * Logical groupings of related messages
+//! * Time range of the data collection
+//! * Detailed information about radar status, scan strategies, and data types
+//!
+//! ## Usage Example
+//!
+//! ```rust
+//! use nexrad_decode::messages::Message;
+//! use nexrad_decode::summarize;
+//!
+//! // Assuming you have parsed messages from a NEXRAD file
+//! let messages: Vec<Message> = /* ... */;
+//!
+//! // Generate a summary
+//! let summary = summarize::messages(&messages);
+//!
+//! // Print the summary
+//! println!("{}", summary);
+//! ```
+
 use crate::messages::{Message, MessageContents, MessageType};
-use chrono::{DateTime, Utc};
 use std::collections::{HashMap, HashSet};
-use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 
-/// Summary of a set of messages.
-#[derive(Clone, PartialEq, Debug)]
-pub struct MessageSummary {
-    /// The distinct volume coverage patterns found in these messages.
-    pub volume_coverage_patterns: HashSet<digital_radar_data::VolumeCoveragePattern>,
+mod message;
+pub use message::MessageSummary;
 
-    /// All messages in sequence, with related messages grouped together
-    pub message_groups: Vec<MessageGroupSummary>,
+mod group;
+pub use group::MessageGroupSummary;
 
-    pub earliest_collection_time: Option<DateTime<Utc>>,
-    pub latest_collection_time: Option<DateTime<Utc>>,
-}
+mod rda;
+pub use rda::RDAStatusInfo;
 
-impl Display for MessageSummary {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        // Time information
-        write!(f, "Scans from ")?;
-        if let Some(start) = self.earliest_collection_time {
-            write!(f, "{}", start.format("%Y-%m-%d %H:%M:%S%.3f UTC"))?;
-        } else {
-            write!(f, "unknown")?;
-        }
+mod vcp;
+pub use vcp::{VCPElevationInfo, VCPInfo};
 
-        write!(f, " to ")?;
-        if let Some(end) = self.latest_collection_time {
-            write!(f, "{}", end.format("%Y-%m-%d %H:%M:%S%.3f UTC"))?;
-            if let Some(start) = self.earliest_collection_time {
-                let duration = end.signed_duration_since(start);
-                write!(f, " ({:.2}m)", duration.num_milliseconds() as f64 / 60000.0)?;
-            }
-        } else {
-            write!(f, "unknown")?;
-        }
-        writeln!(f)?;
-
-        // Volume coverage patterns
-        write!(f, "VCPs: ")?;
-        if self.volume_coverage_patterns.is_empty() {
-            writeln!(f, "none")?;
-        } else {
-            let vcps: Vec<_> = self.volume_coverage_patterns.iter().collect();
-            for (i, vcp) in vcps.iter().enumerate() {
-                if i > 0 {
-                    write!(f, ", ")?;
-                }
-                write!(f, "{:?}", vcp)?;
-            }
-            writeln!(f)?;
-        }
-
-        // Messages
-        writeln!(f, "Messages:")?;
-        for group in self.message_groups.iter() {
-            let prefix = if group.message_type == MessageType::RDADigitalRadarDataGenericFormat {
-                let msg_range = if group.start_message_index == group.end_message_index {
-                    format!("  Msg {}", group.start_message_index + 1)
-                } else {
-                    format!(
-                        "  Msg {}-{}",
-                        group.start_message_index + 1,
-                        group.end_message_index + 1
-                    )
-                };
-
-                if group.is_continued {
-                    format!("{} (cont.)", msg_range)
-                } else {
-                    msg_range
-                }
-            } else if group.start_message_index == group.end_message_index {
-                format!("  Msg {}", group.start_message_index + 1)
-            } else {
-                format!(
-                    "  Msg {}-{}",
-                    group.start_message_index + 1,
-                    group.end_message_index + 1
-                )
-            };
-            writeln!(f, "{}: {}", prefix, group)?;
-        }
-
-        Ok(())
-    }
-}
-
-/// Summary of a single message or group of related messages
-#[derive(Clone, PartialEq, Debug)]
-pub struct MessageGroupSummary {
-    pub message_type: MessageType,
-    pub start_time: Option<DateTime<Utc>>,
-    pub end_time: Option<DateTime<Utc>>,
-    pub message_count: usize,
-
-    // For DigitalRadarData messages
-    pub elevation_number: Option<u8>,
-    pub elevation_angle: Option<f32>,
-    pub start_azimuth: Option<f32>,
-    pub end_azimuth: Option<f32>,
-    pub data_types: Option<HashMap<String, usize>>,
-
-    // For RDAStatusData messages
-    pub rda_status_info: Option<RDAStatusInfo>,
-
-    // For VolumeCoveragePattern messages
-    pub vcp_info: Option<VCPInfo>,
-
-    // Indicates if this group continues from a previous group
-    pub is_continued: bool,
-
-    // Absolute message indices
-    pub start_message_index: usize,
-    pub end_message_index: usize,
-}
-
-/// Contains information from the RDA Status Data message
-#[derive(Clone, PartialEq, Debug)]
-pub struct RDAStatusInfo {
-    pub rda_status: String,
-    pub operability_status: String,
-    pub control_status: String,
-    pub operational_mode: String,
-    pub vcp_number: Option<i16>,
-    pub vcp_is_local: bool,
-    pub average_transmitter_power: u16,
-    pub reflectivity_calibration: f32,
-    pub super_resolution_status: String,
-    pub data_transmission_enabled: Vec<String>,
-    pub has_alarms: bool,
-    pub active_alarms: Vec<String>,
-    pub scan_data_info: Vec<String>,
-}
-
-/// Contains information from the Volume Coverage Pattern message
-#[derive(Clone, PartialEq, Debug)]
-pub struct VCPInfo {
-    pub pattern_number: u16,
-    pub version: u8,
-    pub number_of_elevation_cuts: u16,
-    pub pulse_width: String,
-    pub doppler_velocity_resolution: Option<f64>,
-    pub vcp_features: Vec<String>,
-    pub elevations: Vec<VCPElevationInfo>,
-}
-
-/// Information about a single elevation cut in a VCP
-#[derive(Clone, PartialEq, Debug)]
-pub struct VCPElevationInfo {
-    pub elevation_angle: f64,
-    pub channel_configuration: String,
-    pub waveform_type: String,
-    pub azimuth_rate: f64,
-    pub super_resolution_features: Vec<String>,
-    pub special_cut_type: Option<String>,
-}
-
-impl Display for MessageGroupSummary {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        if self.message_type == MessageType::RDADigitalRadarDataGenericFormat {
-            write!(f, "Elevation: #{}", self.elevation_number.unwrap_or(0))?;
-
-            if let Some(elev_angle) = self.elevation_angle {
-                write!(f, " ({:.2}°)", elev_angle)?;
-            }
-
-            write!(
-                f,
-                ", Azimuth: {:.1}° to {:.1}°",
-                self.start_azimuth.unwrap_or(0.0),
-                self.end_azimuth.unwrap_or(0.0)
-            )?;
-
-            if let Some(start) = self.start_time {
-                write!(f, ", Time: {}", start.format("%H:%M:%S%.3f"))?;
-
-                if let Some(end) = self.end_time {
-                    if start != end {
-                        write!(f, " to {}", end.format("%H:%M:%S%.3f"))?;
-                        let duration = end.signed_duration_since(start);
-                        write!(f, " ({:.2}s)", duration.num_milliseconds() as f64 / 1000.0)?;
-                    }
-                }
-            }
-
-            if let Some(data_types) = &self.data_types {
-                if !data_types.is_empty() {
-                    writeln!(f)?;
-                    write!(f, "    Data types: ")?;
-                    let data_types: Vec<_> = data_types.iter().collect();
-
-                    for (i, (data_type, count)) in data_types.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
-                        }
-
-                        // Use abbreviated names for common data types
-                        let abbr = match data_type.as_str() {
-                            "Reflectivity" => "REF",
-                            "Velocity" => "VEL",
-                            "Spectrum Width" => "SW",
-                            "Differential Reflectivity" => "ZDR",
-                            "Differential Phase" => "DP",
-                            "Correlation Coefficient" => "CC",
-                            "Specific Differential Phase" => "KDP",
-                            _ => data_type,
-                        };
-
-                        write!(f, "{} ({})", abbr, count)?;
-                    }
-                }
-            }
-        } else if self.message_type == MessageType::RDAStatusData {
-            if let Some(status_info) = &self.rda_status_info {
-                write!(
-                    f,
-                    "RDA Status: {}, Operability: {}",
-                    status_info.rda_status, status_info.operability_status
-                )?;
-
-                writeln!(f)?;
-                write!(
-                    f,
-                    "    Control: {}, Mode: {}",
-                    status_info.control_status, status_info.operational_mode
-                )?;
-
-                if let Some(vcp) = status_info.vcp_number {
-                    let source = if status_info.vcp_is_local {
-                        "local"
-                    } else {
-                        "remote"
-                    };
-                    write!(f, ", VCP: {} ({})", vcp, source)?;
-                }
-
-                writeln!(f)?;
-                write!(
-                    f,
-                    "    Transmitter power: {} W, Reflectivity cal: {:.2} dB",
-                    status_info.average_transmitter_power, status_info.reflectivity_calibration
-                )?;
-
-                writeln!(f)?;
-                write!(
-                    f,
-                    "    Super resolution: {}",
-                    status_info.super_resolution_status
-                )?;
-
-                // Data transmission
-                if !status_info.data_transmission_enabled.is_empty() {
-                    writeln!(f)?;
-                    write!(f, "    Data enabled: ")?;
-                    for (i, data_type) in status_info.data_transmission_enabled.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
-                        }
-                        write!(f, "{}", data_type)?;
-                    }
-                }
-
-                // Scan flags
-                if !status_info.scan_data_info.is_empty() {
-                    writeln!(f)?;
-                    write!(f, "    Scan settings: ")?;
-                    for (i, flag) in status_info.scan_data_info.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
-                        }
-                        write!(f, "{}", flag)?;
-                    }
-                }
-
-                // Alarms
-                if status_info.has_alarms {
-                    writeln!(f)?;
-                    write!(f, "    Alarms: ")?;
-                    for (i, alarm) in status_info.active_alarms.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
-                        }
-                        write!(f, "{}", alarm)?;
-                    }
-                }
-            } else {
-                write!(f, "RDA Status Data")?;
-                if self.message_count > 1 {
-                    write!(f, " ({})", self.message_count)?;
-                }
-            }
-        } else if self.message_type == MessageType::RDAVolumeCoveragePattern {
-            if let Some(vcp_info) = &self.vcp_info {
-                write!(
-                    f,
-                    "VCP: #{}, Version: {}",
-                    vcp_info.pattern_number, vcp_info.version
-                )?;
-
-                // Show general VCP information
-                writeln!(f)?;
-                write!(
-                    f,
-                    "    {} elevation cuts, Pulse width: {}",
-                    vcp_info.number_of_elevation_cuts, vcp_info.pulse_width
-                )?;
-
-                if let Some(doppler_res) = vcp_info.doppler_velocity_resolution {
-                    write!(f, ", Doppler resolution: {:.1} m/s", doppler_res)?;
-                }
-
-                // VCP features
-                if !vcp_info.vcp_features.is_empty() {
-                    writeln!(f)?;
-                    write!(f, "    Features: ")?;
-                    for (i, feature) in vcp_info.vcp_features.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
-                        }
-                        write!(f, "{}", feature)?;
-                    }
-                }
-
-                // Show all elevation cuts on separate lines
-                if !vcp_info.elevations.is_empty() {
-                    writeln!(f)?;
-                    writeln!(f, "    Elevation cuts:")?;
-
-                    for (i, elev) in vcp_info.elevations.iter().enumerate() {
-                        write!(f, "      Cut #{}: {:.2}°", i + 1, elev.elevation_angle)?;
-
-                        if let Some(cut_type) = &elev.special_cut_type {
-                            write!(f, " ({})", cut_type)?;
-                        }
-
-                        // Show waveform and channel configuration
-                        write!(
-                            f,
-                            ", {}, {}",
-                            elev.waveform_type, elev.channel_configuration
-                        )?;
-
-                        // Show azimuth rate
-                        write!(f, ", {:.1}°/s", elev.azimuth_rate)?;
-
-                        // Show super resolution features if any
-                        if !elev.super_resolution_features.is_empty() {
-                            write!(f, ", Super res: ")?;
-                            for (j, feature) in elev.super_resolution_features.iter().enumerate() {
-                                if j > 0 {
-                                    write!(f, ", ")?;
-                                }
-                                write!(f, "{}", feature)?;
-                            }
-                        }
-
-                        if i < vcp_info.elevations.len() - 1 {
-                            writeln!(f)?;
-                        }
-                    }
-                }
-            } else {
-                write!(f, "Volume Coverage Pattern")?;
-                if self.message_count > 1 {
-                    write!(f, " ({})", self.message_count)?;
-                }
-            }
-        } else {
-            write!(f, "{:?}", self.message_type)?;
-            if self.message_count > 1 {
-                write!(f, " ({})", self.message_count)?;
-            }
-            if let Some(start) = self.start_time {
-                write!(f, ", Time: {}", start.format("%Y-%m-%d %H:%M:%S%.3f"))?;
-                if let Some(end) = self.end_time {
-                    if start != end {
-                        write!(f, " to {}", end.format("%Y-%m-%d %H:%M:%S%.3f"))?;
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-/// Helper function to extract RDA status information from a message
-fn extract_rda_status_info(message: &crate::messages::rda_status_data::Message) -> RDAStatusInfo {
-    let mut info = RDAStatusInfo {
-        rda_status: format!("{:?}", message.rda_status()),
-        operability_status: format!("{:?}", message.operability_status()),
-        control_status: format!("{:?}", message.control_status()),
-        operational_mode: format!("{:?}", message.operational_mode()),
-        vcp_number: message.volume_coverage_pattern().map(|vcp| vcp.number()),
-        vcp_is_local: message
-            .volume_coverage_pattern()
-            .map(|vcp| vcp.local())
-            .unwrap_or(false),
-        average_transmitter_power: message.average_transmitter_power,
-        reflectivity_calibration: message.horizontal_reflectivity_calibration_correction(),
-        super_resolution_status: format!("{:?}", message.super_resolution_status()),
-        data_transmission_enabled: Vec::new(),
-        has_alarms: !message.rda_alarm_summary().none(),
-        active_alarms: Vec::new(),
-        scan_data_info: Vec::new(),
-    };
-
-    // Data transmission enabled
-    let data_enabled = message.data_transmission_enabled();
-    if data_enabled.none() {
-        info.data_transmission_enabled.push("None".to_string());
-    } else {
-        if data_enabled.reflectivity() {
-            info.data_transmission_enabled
-                .push("Reflectivity".to_string());
-        }
-        if data_enabled.velocity() {
-            info.data_transmission_enabled.push("Velocity".to_string());
-        }
-        if data_enabled.spectrum_width() {
-            info.data_transmission_enabled
-                .push("Spectrum Width".to_string());
-        }
-    }
-
-    // Scan data flags
-    let flags = message.rda_scan_and_data_flags();
-    if flags.avset_enabled() {
-        info.scan_data_info.push("AVSET enabled".to_string());
-    } else {
-        info.scan_data_info.push("AVSET disabled".to_string());
-    }
-    if flags.ebc_enabled() {
-        info.scan_data_info.push("EBC enabled".to_string());
-    }
-    if flags.rda_log_data_enabled() {
-        info.scan_data_info.push("Log data enabled".to_string());
-    }
-    if flags.time_series_data_recording_enabled() {
-        info.scan_data_info
-            .push("Time series recording enabled".to_string());
-    }
-
-    // Alarms
-    let alarms = message.rda_alarm_summary();
-    if alarms.tower_utilities() {
-        info.active_alarms.push("Tower/utilities".to_string());
-    }
-    if alarms.pedestal() {
-        info.active_alarms.push("Pedestal".to_string());
-    }
-    if alarms.transmitter() {
-        info.active_alarms.push("Transmitter".to_string());
-    }
-    if alarms.receiver() {
-        info.active_alarms.push("Receiver".to_string());
-    }
-    if alarms.rda_control() {
-        info.active_alarms.push("RDA control".to_string());
-    }
-    if alarms.communication() {
-        info.active_alarms.push("Communication".to_string());
-    }
-    if alarms.signal_processor() {
-        info.active_alarms.push("Signal processor".to_string());
-    }
-
-    info
-}
-
-/// Helper function to extract Volume Coverage Pattern information from a message
-fn extract_vcp_info(message: &crate::messages::volume_coverage_pattern::Message) -> VCPInfo {
-    let mut vcp_features = Vec::new();
-
-    // Add VCP features
-    if message.header.vcp_supplemental_data_sails_vcp() {
-        let sails_cuts = message.header.vcp_supplemental_data_number_sails_cuts();
-        vcp_features.push(format!("SAILS ({} cuts)", sails_cuts));
-    }
-
-    if message.header.vcp_supplemental_data_mrle_vcp() {
-        let mrle_cuts = message.header.vcp_supplemental_data_number_mrle_cuts();
-        vcp_features.push(format!("MRLE ({} cuts)", mrle_cuts));
-    }
-
-    if message.header.vcp_supplemental_data_mpda_vcp() {
-        vcp_features.push("MPDA".to_string());
-    }
-
-    if message.header.vcp_supplemental_data_base_tilt_vcp() {
-        let base_tilts = message.header.vcp_supplemental_data_base_tilts();
-        vcp_features.push(format!("Base tilts ({} cuts)", base_tilts));
-    }
-
-    if message.header.vcp_sequencing_sequence_active() {
-        vcp_features.push("VCP sequence active".to_string());
-    }
-
-    if message.header.vcp_sequencing_truncated_vcp() {
-        vcp_features.push("Truncated VCP".to_string());
-    }
-
-    // Create elevations info
-    let mut elevations = Vec::new();
-    for elev in &message.elevations {
-        let mut super_res_features = Vec::new();
-        if elev.super_resolution_control_half_degree_azimuth() {
-            super_res_features.push("0.5° azimuth".to_string());
-        }
-        if elev.super_resolution_control_quarter_km_reflectivity() {
-            super_res_features.push("0.25 km reflectivity".to_string());
-        }
-        if elev.super_resolution_control_doppler_to_300km() {
-            super_res_features.push("Doppler to 300 km".to_string());
-        }
-        if elev.super_resolution_control_dual_polarization_to_300km() {
-            super_res_features.push("Dual pol to 300 km".to_string());
-        }
-
-        // Determine special cut type
-        let mut special_cut_type = None;
-        if elev.supplemental_data_sails_cut() {
-            let seq = elev.supplemental_data_sails_sequence_number();
-            special_cut_type = Some(format!("SAILS {}", seq));
-        } else if elev.supplemental_data_mrle_cut() {
-            let seq = elev.supplemental_data_mrle_sequence_number();
-            special_cut_type = Some(format!("MRLE {}", seq));
-        } else if elev.supplemental_data_mpda_cut() {
-            special_cut_type = Some("MPDA".to_string());
-        } else if elev.supplemental_data_base_tilt_cut() {
-            special_cut_type = Some("Base tilt".to_string());
-        }
-
-        elevations.push(VCPElevationInfo {
-            elevation_angle: elev.elevation_angle_degrees(),
-            channel_configuration: format!("{:?}", elev.channel_configuration()),
-            waveform_type: format!("{:?}", elev.waveform_type()),
-            azimuth_rate: elev.azimuth_rate_degrees_per_second(),
-            super_resolution_features: super_res_features,
-            special_cut_type,
-        });
-    }
-
-    VCPInfo {
-        pattern_number: message.header.pattern_number,
-        version: message.header.version,
-        number_of_elevation_cuts: message.header.number_of_elevation_cuts,
-        pulse_width: format!("{:?}", message.header.pulse_width()),
-        doppler_velocity_resolution: message
-            .header
-            .doppler_velocity_resolution_meters_per_second(),
-        vcp_features,
-        elevations,
-    }
-}
-
-/// Provides a summary of the given messages.
+/// Processes a collection of NEXRAD messages and generates a comprehensive summary.
+///
+/// This function analyzes the provided messages and organizes them into logical groups
+/// based on their type and content. It extracts key information such as:
+///
+/// * Volume coverage patterns
+/// * Time range of data collection
+/// * Radar operational status
+/// * Scan strategy details
+/// * Data types present in each elevation cut
+///
+/// The function handles various message types including:
+/// * Digital Radar Data messages (reflectivity, velocity, etc.)
+/// * RDA Status Data messages
+/// * Volume Coverage Pattern messages
+/// * Other message types
+///
+/// Messages of the same type and characteristics are grouped together to provide
+/// a more concise and understandable summary.
 pub fn messages(messages: &[Message]) -> MessageSummary {
     let mut summary = MessageSummary {
         volume_coverage_patterns: HashSet::new(),
@@ -695,7 +201,7 @@ pub fn messages(messages: &[Message]) -> MessageSummary {
                     start_azimuth: None,
                     end_azimuth: None,
                     data_types: None,
-                    rda_status_info: Some(extract_rda_status_info(status_data)),
+                    rda_status_info: Some(rda::extract_rda_status_info(status_data)),
                     vcp_info: None,
                     is_continued: false,
                     start_message_index: i,
@@ -719,7 +225,7 @@ pub fn messages(messages: &[Message]) -> MessageSummary {
                     end_azimuth: None,
                     data_types: None,
                     rda_status_info: None,
-                    vcp_info: Some(extract_vcp_info(vcp_data)),
+                    vcp_info: Some(vcp::extract_vcp_info(vcp_data)),
                     is_continued: false,
                     start_message_index: i,
                     end_message_index: i,

--- a/nexrad-decode/src/summarize.rs
+++ b/nexrad-decode/src/summarize.rs
@@ -197,21 +197,22 @@ pub fn messages(messages: &[Message]) -> MessageSummary {
         let message_type = message.header().message_type();
         let message_time = message.header().date_time();
 
-        if let Some(time) = message_time {
-            if summary.earliest_collection_time.is_none()
-                || summary.earliest_collection_time > Some(time)
-            {
-                summary.earliest_collection_time = Some(time);
-            }
-            if summary.latest_collection_time.is_none()
-                || summary.latest_collection_time < Some(time)
-            {
-                summary.latest_collection_time = Some(time);
-            }
-        }
-
         match message.contents() {
             MessageContents::DigitalRadarData(radar_data) => {
+                if let Some(time) = message_time {
+                    if (summary.earliest_collection_time.is_none()
+                        || summary.earliest_collection_time > Some(time))
+                        && time.timestamp_millis() > 0
+                    {
+                        summary.earliest_collection_time = Some(time);
+                    }
+                    if summary.latest_collection_time.is_none()
+                        || summary.latest_collection_time < Some(time)
+                    {
+                        summary.latest_collection_time = Some(time);
+                    }
+                }
+
                 let elevation_number = radar_data.header.elevation_number;
 
                 let can_continue = if let Some(group) = &current_group {

--- a/nexrad-decode/src/summarize.rs
+++ b/nexrad-decode/src/summarize.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 
 /// Summary of a set of messages.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct MessageSummary {
     /// The distinct volume coverage patterns found in these messages.
     pub volume_coverage_patterns: HashSet<digital_radar_data::VolumeCoveragePattern>,
@@ -21,28 +21,8 @@ pub struct MessageSummary {
     pub latest_collection_time: Option<DateTime<Utc>>,
 }
 
-impl Debug for MessageSummary {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut debug = f.debug_struct("MessageSummary");
-        debug.field("volume_coverage_patterns", &self.volume_coverage_patterns);
-
-        let message_types_string = self
-            .message_types
-            .iter()
-            .map(|(k, v)| format!("{:?}: {}", k, v))
-            .collect::<Vec<_>>();
-
-        debug.field("message_types", &message_types_string);
-
-        debug.field("scans", &self.scans);
-        debug.field("earliest_collection_time", &self.earliest_collection_time);
-        debug.field("latest_collection_time", &self.latest_collection_time);
-        debug.finish()
-    }
-}
-
 /// Summary of a single scan.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct ScanSummary {
     pub start_time: Option<DateTime<Utc>>,
     pub end_time: Option<DateTime<Utc>>,
@@ -54,27 +34,6 @@ pub struct ScanSummary {
 
     /// The number of messages containing a given radar data type.
     pub data_types: HashMap<String, usize>,
-}
-
-impl Debug for ScanSummary {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut debug = f.debug_struct("ScanSummary");
-        debug.field("start_time", &self.start_time);
-        debug.field("end_time", &self.end_time);
-        debug.field("elevation", &self.elevation);
-        debug.field("start_azimuth", &self.start_azimuth);
-        debug.field("end_azimuth", &self.end_azimuth);
-
-        let data_types_string = self
-            .data_types
-            .iter()
-            .map(|(k, v)| format!("{}: {}", k, v))
-            .collect::<Vec<_>>();
-
-        debug.field("data_types", &data_types_string);
-
-        debug.finish()
-    }
 }
 
 /// Provides a summary of the given messages.

--- a/nexrad-decode/src/summarize.rs
+++ b/nexrad-decode/src/summarize.rs
@@ -10,12 +10,8 @@ pub struct MessageSummary {
     /// The distinct volume coverage patterns found in these messages.
     pub volume_coverage_patterns: HashSet<digital_radar_data::VolumeCoveragePattern>,
 
-    /// The number of messages of each type in the order they appear. Multiple messages of the same
-    /// type will be grouped together if consecutive.
-    pub message_types: Vec<(MessageType, usize)>,
-
-    /// Summaries of each scan found in these messages.
-    pub scans: Vec<ScanSummary>,
+    /// All messages in sequence, with related messages grouped together
+    pub message_groups: Vec<MessageGroupSummary>,
 
     pub earliest_collection_time: Option<DateTime<Utc>>,
     pub latest_collection_time: Option<DateTime<Utc>>,
@@ -29,7 +25,7 @@ impl Display for MessageSummary {
         } else {
             write!(f, "Start: unknown")?;
         }
-        
+
         if let Some(end) = self.latest_collection_time {
             write!(f, ", End: {}", end.format("%Y-%m-%d %H:%M:%S%.3f UTC"))?;
             if let Some(start) = self.earliest_collection_time {
@@ -40,7 +36,7 @@ impl Display for MessageSummary {
             write!(f, ", End: unknown")?;
         }
         writeln!(f)?;
-        
+
         // Volume coverage patterns
         write!(f, "VCPs: ")?;
         if self.volume_coverage_patterns.is_empty() {
@@ -55,89 +51,134 @@ impl Display for MessageSummary {
             }
             writeln!(f)?;
         }
-        
-        // Message types
-        writeln!(f, "Message types:")?;
-        for (msg_type, count) in &self.message_types {
-            writeln!(f, "  {:?}: {}", msg_type, count)?;
+
+        // Messages
+        writeln!(f, "Messages:")?;
+        for group in self.message_groups.iter() {
+            let prefix = if group.message_type == MessageType::RDADigitalRadarDataGenericFormat {
+                let msg_range = if group.start_message_index == group.end_message_index {
+                    format!("  Msg {}", group.start_message_index + 1)
+                } else {
+                    format!(
+                        "  Msg {}-{}",
+                        group.start_message_index + 1,
+                        group.end_message_index + 1
+                    )
+                };
+
+                if group.is_continued {
+                    format!("{} (cont.)", msg_range)
+                } else {
+                    msg_range
+                }
+            } else if group.start_message_index == group.end_message_index {
+                format!("  Msg {}", group.start_message_index + 1)
+            } else {
+                format!(
+                    "  Msg {}-{}",
+                    group.start_message_index + 1,
+                    group.end_message_index + 1
+                )
+            };
+            writeln!(f, "{}: {}", prefix, group)?;
         }
-        
-        // Scans
-        writeln!(f, "Scans: {}", self.scans.len())?;
-        for (i, scan) in self.scans.iter().enumerate() {
-            writeln!(f, "  Scan {}: {}", i + 1, scan)?;
-        }
-        
+
         Ok(())
     }
 }
 
-/// Summary of a single scan.
+/// Summary of a single message or group of related messages
 #[derive(Clone, PartialEq, Debug)]
-pub struct ScanSummary {
+pub struct MessageGroupSummary {
+    pub message_type: MessageType,
     pub start_time: Option<DateTime<Utc>>,
     pub end_time: Option<DateTime<Utc>>,
+    pub message_count: usize,
 
-    pub elevation_number: u8,
+    // For DigitalRadarData messages
+    pub elevation_number: Option<u8>,
     pub elevation_angle: Option<f32>,
+    pub start_azimuth: Option<f32>,
+    pub end_azimuth: Option<f32>,
+    pub data_types: Option<HashMap<String, usize>>,
 
-    pub start_azimuth: f32,
-    pub end_azimuth: f32,
+    // Indicates if this group continues from a previous group
+    pub is_continued: bool,
 
-    /// The number of messages containing a given radar data type.
-    pub data_types: HashMap<String, usize>,
-    
-    message_count: usize,
+    // Absolute message indices
+    pub start_message_index: usize,
+    pub end_message_index: usize,
 }
 
-impl Display for ScanSummary {
+impl Display for MessageGroupSummary {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "Elevation: #{}", self.elevation_number)?;
-        
-        if let Some(elev_angle) = self.elevation_angle {
-            write!(f, " ({:.2}°)", elev_angle)?;
-        }
-        
-        write!(f, ", Azimuth: {:.1}° to {:.1}°", self.start_azimuth, self.end_azimuth)?;
-        
-        if let Some(start) = self.start_time {
-            write!(f, ", Time: {}", start.format("%H:%M:%S%.3f"))?;
-            
-            if let Some(end) = self.end_time {
-                if start != end {
-                    write!(f, " to {}", end.format("%H:%M:%S%.3f"))?;
-                    let duration = end.signed_duration_since(start);
-                    write!(f, " ({:.2}s)", duration.num_milliseconds() as f64 / 1000.0)?;
+        if self.message_type == MessageType::RDADigitalRadarDataGenericFormat {
+            write!(f, "Elevation: #{}", self.elevation_number.unwrap_or(0))?;
+
+            if let Some(elev_angle) = self.elevation_angle {
+                write!(f, " ({:.2}°)", elev_angle)?;
+            }
+
+            write!(
+                f,
+                ", Azimuth: {:.1}° to {:.1}°",
+                self.start_azimuth.unwrap_or(0.0),
+                self.end_azimuth.unwrap_or(0.0)
+            )?;
+
+            if let Some(start) = self.start_time {
+                write!(f, ", Time: {}", start.format("%H:%M:%S%.3f"))?;
+
+                if let Some(end) = self.end_time {
+                    if start != end {
+                        write!(f, " to {}", end.format("%H:%M:%S%.3f"))?;
+                        let duration = end.signed_duration_since(start);
+                        write!(f, " ({:.2}s)", duration.num_milliseconds() as f64 / 1000.0)?;
+                    }
+                }
+            }
+
+            if let Some(data_types) = &self.data_types {
+                if !data_types.is_empty() {
+                    writeln!(f)?;
+                    write!(f, "    Data types: ")?;
+                    let data_types: Vec<_> = data_types.iter().collect();
+
+                    for (i, (data_type, count)) in data_types.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+
+                        // Use abbreviated names for common data types
+                        let abbr = match data_type.as_str() {
+                            "Reflectivity" => "REF",
+                            "Velocity" => "VEL",
+                            "Spectrum Width" => "SW",
+                            "Differential Reflectivity" => "ZDR",
+                            "Differential Phase" => "DP",
+                            "Correlation Coefficient" => "CC",
+                            "Specific Differential Phase" => "KDP",
+                            _ => data_type,
+                        };
+
+                        write!(f, "{} ({})", abbr, count)?;
+                    }
+                }
+            }
+        } else {
+            write!(f, "{:?}", self.message_type)?;
+            if self.message_count > 1 {
+                write!(f, " ({})", self.message_count)?;
+            }
+            if let Some(start) = self.start_time {
+                write!(f, ", Time: {}", start.format("%H:%M:%S%.3f"))?;
+                if let Some(end) = self.end_time {
+                    if start != end {
+                        write!(f, " to {}", end.format("%H:%M:%S%.3f"))?;
+                    }
                 }
             }
         }
-        
-        if !self.data_types.is_empty() {
-            writeln!(f, "")?;
-            write!(f, "    Data types: ")?;
-            let data_types: Vec<_> = self.data_types.iter().collect();
-            
-            for (i, (data_type, count)) in data_types.iter().enumerate() {
-                if i > 0 {
-                    write!(f, ", ")?;
-                }
-                
-                // Use abbreviated names for common data types
-                let abbr = match data_type.as_str() {
-                    "Reflectivity" => "REF",
-                    "Velocity" => "VEL",
-                    "Spectrum Width" => "SW",
-                    "Differential Reflectivity" => "ZDR",
-                    "Differential Phase" => "DP",
-                    "Correlation Coefficient" => "CC",
-                    "Specific Differential Phase" => "KDP",
-                    _ => data_type, // Keep other names unchanged
-                };
-                
-                write!(f, "{} ({})", abbr, count)?;
-            }
-        }
-        
         Ok(())
     }
 }
@@ -146,128 +187,145 @@ impl Display for ScanSummary {
 pub fn messages(messages: &[Message]) -> MessageSummary {
     let mut summary = MessageSummary {
         volume_coverage_patterns: HashSet::new(),
-        message_types: Vec::new(),
-        scans: Vec::new(),
+        message_groups: Vec::new(),
         earliest_collection_time: None,
         latest_collection_time: None,
     };
 
-    let mut scan_summary = None;
-    for message in messages {
-        process_message(&mut summary, &mut scan_summary, message);
+    let mut current_group: Option<MessageGroupSummary> = None;
+    for (i, message) in messages.iter().enumerate() {
+        let message_type = message.header().message_type();
+        let message_time = message.header().date_time();
+
+        if let Some(time) = message_time {
+            if summary.earliest_collection_time.is_none()
+                || summary.earliest_collection_time > Some(time)
+            {
+                summary.earliest_collection_time = Some(time);
+            }
+            if summary.latest_collection_time.is_none()
+                || summary.latest_collection_time < Some(time)
+            {
+                summary.latest_collection_time = Some(time);
+            }
+        }
+
+        match message.contents() {
+            MessageContents::DigitalRadarData(radar_data) => {
+                let elevation_number = radar_data.header.elevation_number;
+
+                let can_continue = if let Some(group) = &current_group {
+                    group.message_type == MessageType::RDADigitalRadarDataGenericFormat
+                        && group.elevation_number == Some(elevation_number)
+                } else {
+                    false
+                };
+
+                if !can_continue {
+                    if let Some(group) = current_group.take() {
+                        summary.message_groups.push(group);
+                    }
+
+                    current_group = Some(MessageGroupSummary {
+                        message_type: MessageType::RDADigitalRadarDataGenericFormat,
+                        start_time: message_time,
+                        end_time: message_time,
+                        message_count: 1,
+                        elevation_number: Some(elevation_number),
+                        elevation_angle: Some(radar_data.header.elevation_angle),
+                        start_azimuth: Some(radar_data.header.azimuth_angle),
+                        end_azimuth: Some(radar_data.header.azimuth_angle),
+                        data_types: Some(HashMap::new()),
+                        is_continued: !summary.message_groups.is_empty()
+                            && summary.message_groups.iter().rev().any(|g| {
+                                g.message_type == MessageType::RDADigitalRadarDataGenericFormat
+                                    && g.elevation_number == Some(elevation_number)
+                            }),
+                        start_message_index: i,
+                        end_message_index: i,
+                    });
+                } else if let Some(group) = &mut current_group {
+                    group.end_time = message_time;
+                    group.message_count += 1;
+                    group.end_azimuth = Some(radar_data.header.azimuth_angle);
+                    group.end_message_index = i;
+                }
+
+                if let Some(group) = &mut current_group {
+                    if let Some(data_types) = group.data_types.as_mut() {
+                        let mut increment_count = |data_type: &str| {
+                            let count = data_types.get(data_type).unwrap_or(&0) + 1;
+                            data_types.insert(data_type.to_string(), count);
+                        };
+
+                        if radar_data.reflectivity_data_block.is_some() {
+                            increment_count("Reflectivity");
+                        }
+                        if radar_data.velocity_data_block.is_some() {
+                            increment_count("Velocity");
+                        }
+                        if radar_data.spectrum_width_data_block.is_some() {
+                            increment_count("Spectrum Width");
+                        }
+                        if radar_data.differential_reflectivity_data_block.is_some() {
+                            increment_count("Differential Reflectivity");
+                        }
+                        if radar_data.differential_phase_data_block.is_some() {
+                            increment_count("Differential Phase");
+                        }
+                        if radar_data.correlation_coefficient_data_block.is_some() {
+                            increment_count("Correlation Coefficient");
+                        }
+                        if radar_data.specific_diff_phase_data_block.is_some() {
+                            increment_count("Specific Differential Phase");
+                        }
+                    }
+                }
+
+                if let Some(volume_data) = &radar_data.volume_data_block {
+                    summary
+                        .volume_coverage_patterns
+                        .insert(volume_data.volume_coverage_pattern());
+                }
+            }
+            _ => {
+                let can_combine = if let Some(group) = &current_group {
+                    group.message_type == message_type
+                } else {
+                    false
+                };
+
+                if !can_combine {
+                    if let Some(group) = current_group.take() {
+                        summary.message_groups.push(group);
+                    }
+
+                    current_group = Some(MessageGroupSummary {
+                        message_type,
+                        start_time: message_time,
+                        end_time: message_time,
+                        message_count: 1,
+                        elevation_number: None,
+                        elevation_angle: None,
+                        start_azimuth: None,
+                        end_azimuth: None,
+                        data_types: None,
+                        is_continued: false,
+                        start_message_index: i,
+                        end_message_index: i,
+                    });
+                } else if let Some(group) = &mut current_group {
+                    group.end_time = message_time;
+                    group.message_count += 1;
+                    group.end_message_index = i;
+                }
+            }
+        }
     }
 
-    if let Some(scan_summary) = scan_summary.take() {
-        summary.scans.push(scan_summary);
+    if let Some(group) = current_group {
+        summary.message_groups.push(group);
     }
 
     summary
-}
-
-fn process_message(
-    summary: &mut MessageSummary,
-    scan_summary: &mut Option<ScanSummary>,
-    message: &Message,
-) {
-    let message_type = message.header().message_type();
-    if let Some((last_message_type, count)) = summary.message_types.last_mut() {
-        if *last_message_type == message_type {
-            *count += 1;
-        } else {
-            summary.message_types.push((message_type, 1));
-        }
-    } else {
-        summary.message_types.push((message_type, 1));
-    }
-
-    if let MessageContents::DigitalRadarData(radar_data_message) = message.contents() {
-        process_digital_radar_data_message(summary, scan_summary, radar_data_message);
-    }
-}
-
-fn process_digital_radar_data_message(
-    summary: &mut MessageSummary,
-    scan_summary: &mut Option<ScanSummary>,
-    message: &digital_radar_data::Message,
-) {
-    let elevation_changed =
-        |summary: &mut ScanSummary| summary.elevation_number != message.header.elevation_number;
-
-    if let Some(scan_summary) = scan_summary.take_if(elevation_changed) {
-        summary.scans.push(scan_summary);
-    }
-
-    let scan_summary = scan_summary.get_or_insert_with(|| ScanSummary {
-        start_time: message.header.date_time(),
-        end_time: message.header.date_time(),
-        elevation_number: message.header.elevation_number,
-        elevation_angle: None,
-        start_azimuth: message.header.azimuth_angle,
-        end_azimuth: message.header.azimuth_angle,
-        data_types: HashMap::new(),
-        message_count: 0,
-    });
-
-    scan_summary.message_count += 1;
-    if scan_summary.elevation_angle.is_none() && scan_summary.message_count > 50 {
-        scan_summary.elevation_angle = Some(message.header.elevation_angle);
-    }
-
-    if message.header.date_time().is_some() {
-        if summary.earliest_collection_time.is_none()
-            || summary.earliest_collection_time > message.header.date_time()
-        {
-            summary.earliest_collection_time = message.header.date_time();
-        }
-
-        if summary.latest_collection_time.is_none()
-            || summary.latest_collection_time < message.header.date_time()
-        {
-            summary.latest_collection_time = message.header.date_time();
-        }
-
-        if scan_summary.start_time.is_none() || scan_summary.start_time > message.header.date_time()
-        {
-            scan_summary.start_time = message.header.date_time();
-        }
-
-        if scan_summary.end_time.is_none() || scan_summary.end_time < message.header.date_time() {
-            scan_summary.end_time = message.header.date_time();
-        }
-    }
-
-    if let Some(volume_data) = &message.volume_data_block {
-        summary
-            .volume_coverage_patterns
-            .insert(volume_data.volume_coverage_pattern());
-    }
-
-    scan_summary.end_azimuth = message.header.azimuth_angle;
-
-    let mut increment_count = |data_type: &str| {
-        let count = scan_summary.data_types.get(data_type).unwrap_or(&0) + 1;
-        scan_summary.data_types.insert(data_type.to_string(), count);
-    };
-
-    if message.reflectivity_data_block.is_some() {
-        increment_count("Reflectivity");
-    }
-    if message.velocity_data_block.is_some() {
-        increment_count("Velocity");
-    }
-    if message.spectrum_width_data_block.is_some() {
-        increment_count("Spectrum Width");
-    }
-    if message.differential_reflectivity_data_block.is_some() {
-        increment_count("Differential Reflectivity");
-    }
-    if message.differential_phase_data_block.is_some() {
-        increment_count("Differential Phase");
-    }
-    if message.correlation_coefficient_data_block.is_some() {
-        increment_count("Correlation Coefficient");
-    }
-    if message.specific_diff_phase_data_block.is_some() {
-        increment_count("Specific Differential Phase");
-    }
 }

--- a/nexrad-decode/src/summarize/group.rs
+++ b/nexrad-decode/src/summarize/group.rs
@@ -1,0 +1,264 @@
+use super::{RDAStatusInfo, VCPInfo};
+use crate::messages::MessageType;
+use chrono::{DateTime, Utc};
+use std::{
+    collections::HashMap,
+    fmt::{Display, Formatter, Result},
+};
+
+/// Summary of a single message or group of related messages
+#[derive(Clone, PartialEq, Debug)]
+pub struct MessageGroupSummary {
+    pub message_type: MessageType,
+    pub start_time: Option<DateTime<Utc>>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub message_count: usize,
+
+    // For DigitalRadarData messages
+    pub elevation_number: Option<u8>,
+    pub elevation_angle: Option<f32>,
+    pub start_azimuth: Option<f32>,
+    pub end_azimuth: Option<f32>,
+    pub data_types: Option<HashMap<String, usize>>,
+
+    // For RDAStatusData messages
+    pub rda_status_info: Option<RDAStatusInfo>,
+
+    // For VolumeCoveragePattern messages
+    pub vcp_info: Option<VCPInfo>,
+
+    // Indicates if this group continues from a previous group
+    pub is_continued: bool,
+
+    // Absolute message indices
+    pub start_message_index: usize,
+    pub end_message_index: usize,
+}
+
+impl Display for MessageGroupSummary {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        if self.message_type == MessageType::RDADigitalRadarDataGenericFormat {
+            write!(f, "Elevation: #{}", self.elevation_number.unwrap_or(0))?;
+
+            if let Some(elev_angle) = self.elevation_angle {
+                write!(f, " ({:.2}°)", elev_angle)?;
+            }
+
+            write!(
+                f,
+                ", Azimuth: {:.1}° to {:.1}°",
+                self.start_azimuth.unwrap_or(0.0),
+                self.end_azimuth.unwrap_or(0.0)
+            )?;
+
+            if let Some(start) = self.start_time {
+                write!(f, ", Time: {}", start.format("%H:%M:%S%.3f"))?;
+
+                if let Some(end) = self.end_time {
+                    if start != end {
+                        write!(f, " to {}", end.format("%H:%M:%S%.3f"))?;
+                        let duration = end.signed_duration_since(start);
+                        write!(f, " ({:.2}s)", duration.num_milliseconds() as f64 / 1000.0)?;
+                    }
+                }
+            }
+
+            if let Some(data_types) = &self.data_types {
+                if !data_types.is_empty() {
+                    writeln!(f)?;
+                    write!(f, "    Data types: ")?;
+                    let data_types: Vec<_> = data_types.iter().collect();
+
+                    for (i, (data_type, count)) in data_types.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+
+                        // Use abbreviated names for common data types
+                        let abbr = match data_type.as_str() {
+                            "Reflectivity" => "REF",
+                            "Velocity" => "VEL",
+                            "Spectrum Width" => "SW",
+                            "Differential Reflectivity" => "ZDR",
+                            "Differential Phase" => "DP",
+                            "Correlation Coefficient" => "CC",
+                            "Specific Differential Phase" => "KDP",
+                            _ => data_type,
+                        };
+
+                        write!(f, "{} ({})", abbr, count)?;
+                    }
+                }
+            }
+        } else if self.message_type == MessageType::RDAStatusData {
+            if let Some(status_info) = &self.rda_status_info {
+                write!(
+                    f,
+                    "RDA Status: {}, Operability: {}",
+                    status_info.rda_status, status_info.operability_status
+                )?;
+
+                writeln!(f)?;
+                write!(
+                    f,
+                    "    Control: {}, Mode: {}",
+                    status_info.control_status, status_info.operational_mode
+                )?;
+
+                if let Some(vcp) = status_info.vcp_number {
+                    let source = if status_info.vcp_is_local {
+                        "local"
+                    } else {
+                        "remote"
+                    };
+                    write!(f, ", VCP: {} ({})", vcp, source)?;
+                }
+
+                writeln!(f)?;
+                write!(
+                    f,
+                    "    Transmitter power: {} W, Reflectivity cal: {:.2} dB",
+                    status_info.average_transmitter_power, status_info.reflectivity_calibration
+                )?;
+
+                writeln!(f)?;
+                write!(
+                    f,
+                    "    Super resolution: {}",
+                    status_info.super_resolution_status
+                )?;
+
+                // Data transmission
+                if !status_info.data_transmission_enabled.is_empty() {
+                    writeln!(f)?;
+                    write!(f, "    Data enabled: ")?;
+                    for (i, data_type) in status_info.data_transmission_enabled.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", data_type)?;
+                    }
+                }
+
+                // Scan flags
+                if !status_info.scan_data_info.is_empty() {
+                    writeln!(f)?;
+                    write!(f, "    Scan settings: ")?;
+                    for (i, flag) in status_info.scan_data_info.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", flag)?;
+                    }
+                }
+
+                // Alarms
+                if status_info.has_alarms {
+                    writeln!(f)?;
+                    write!(f, "    Alarms: ")?;
+                    for (i, alarm) in status_info.active_alarms.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", alarm)?;
+                    }
+                }
+            } else {
+                write!(f, "RDA Status Data")?;
+                if self.message_count > 1 {
+                    write!(f, " ({})", self.message_count)?;
+                }
+            }
+        } else if self.message_type == MessageType::RDAVolumeCoveragePattern {
+            if let Some(vcp_info) = &self.vcp_info {
+                write!(
+                    f,
+                    "VCP: #{}, Version: {}",
+                    vcp_info.pattern_number, vcp_info.version
+                )?;
+
+                // Show general VCP information
+                writeln!(f)?;
+                write!(
+                    f,
+                    "    {} elevation cuts, Pulse width: {}",
+                    vcp_info.number_of_elevation_cuts, vcp_info.pulse_width
+                )?;
+
+                if let Some(doppler_res) = vcp_info.doppler_velocity_resolution {
+                    write!(f, ", Doppler resolution: {:.1} m/s", doppler_res)?;
+                }
+
+                // VCP features
+                if !vcp_info.vcp_features.is_empty() {
+                    writeln!(f)?;
+                    write!(f, "    Features: ")?;
+                    for (i, feature) in vcp_info.vcp_features.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", feature)?;
+                    }
+                }
+
+                // Show all elevation cuts on separate lines
+                if !vcp_info.elevations.is_empty() {
+                    writeln!(f)?;
+                    writeln!(f, "    Elevation cuts:")?;
+
+                    for (i, elev) in vcp_info.elevations.iter().enumerate() {
+                        write!(f, "      Cut #{}: {:.2}°", i + 1, elev.elevation_angle)?;
+
+                        if let Some(cut_type) = &elev.special_cut_type {
+                            write!(f, " ({})", cut_type)?;
+                        }
+
+                        // Show waveform and channel configuration
+                        write!(
+                            f,
+                            ", {}, {}",
+                            elev.waveform_type, elev.channel_configuration
+                        )?;
+
+                        // Show azimuth rate
+                        write!(f, ", {:.1}°/s", elev.azimuth_rate)?;
+
+                        // Show super resolution features if any
+                        if !elev.super_resolution_features.is_empty() {
+                            write!(f, ", Super res: ")?;
+                            for (j, feature) in elev.super_resolution_features.iter().enumerate() {
+                                if j > 0 {
+                                    write!(f, ", ")?;
+                                }
+                                write!(f, "{}", feature)?;
+                            }
+                        }
+
+                        if i < vcp_info.elevations.len() - 1 {
+                            writeln!(f)?;
+                        }
+                    }
+                }
+            } else {
+                write!(f, "Volume Coverage Pattern")?;
+                if self.message_count > 1 {
+                    write!(f, " ({})", self.message_count)?;
+                }
+            }
+        } else {
+            write!(f, "{:?}", self.message_type)?;
+            if self.message_count > 1 {
+                write!(f, " ({})", self.message_count)?;
+            }
+            if let Some(start) = self.start_time {
+                write!(f, ", Time: {}", start.format("%Y-%m-%d %H:%M:%S%.3f"))?;
+                if let Some(end) = self.end_time {
+                    if start != end {
+                        write!(f, " to {}", end.format("%Y-%m-%d %H:%M:%S%.3f"))?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/nexrad-decode/src/summarize/message.rs
+++ b/nexrad-decode/src/summarize/message.rs
@@ -1,0 +1,94 @@
+use chrono::{DateTime, Utc};
+
+use crate::messages::{digital_radar_data, MessageType};
+use std::{
+    collections::HashSet,
+    fmt::{Display, Formatter, Result},
+};
+
+use super::MessageGroupSummary;
+
+/// Summary of a set of messages.
+#[derive(Clone, PartialEq, Debug)]
+pub struct MessageSummary {
+    /// The distinct volume coverage patterns found in these messages.
+    pub volume_coverage_patterns: HashSet<digital_radar_data::VolumeCoveragePattern>,
+
+    /// All messages in sequence, with related messages grouped together
+    pub message_groups: Vec<MessageGroupSummary>,
+
+    pub earliest_collection_time: Option<DateTime<Utc>>,
+    pub latest_collection_time: Option<DateTime<Utc>>,
+}
+
+impl Display for MessageSummary {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        // Time information
+        write!(f, "Scans from ")?;
+        if let Some(start) = self.earliest_collection_time {
+            write!(f, "{}", start.format("%Y-%m-%d %H:%M:%S%.3f UTC"))?;
+        } else {
+            write!(f, "unknown")?;
+        }
+
+        write!(f, " to ")?;
+        if let Some(end) = self.latest_collection_time {
+            write!(f, "{}", end.format("%Y-%m-%d %H:%M:%S%.3f UTC"))?;
+            if let Some(start) = self.earliest_collection_time {
+                let duration = end.signed_duration_since(start);
+                write!(f, " ({:.2}m)", duration.num_milliseconds() as f64 / 60000.0)?;
+            }
+        } else {
+            write!(f, "unknown")?;
+        }
+        writeln!(f)?;
+
+        // Volume coverage patterns
+        write!(f, "VCPs: ")?;
+        if self.volume_coverage_patterns.is_empty() {
+            writeln!(f, "none")?;
+        } else {
+            let vcps: Vec<_> = self.volume_coverage_patterns.iter().collect();
+            for (i, vcp) in vcps.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{:?}", vcp)?;
+            }
+            writeln!(f)?;
+        }
+
+        // Messages
+        writeln!(f, "Messages:")?;
+        for group in self.message_groups.iter() {
+            let prefix = if group.message_type == MessageType::RDADigitalRadarDataGenericFormat {
+                let msg_range = if group.start_message_index == group.end_message_index {
+                    format!("  Msg {}", group.start_message_index + 1)
+                } else {
+                    format!(
+                        "  Msg {}-{}",
+                        group.start_message_index + 1,
+                        group.end_message_index + 1
+                    )
+                };
+
+                if group.is_continued {
+                    format!("{} (cont.)", msg_range)
+                } else {
+                    msg_range
+                }
+            } else if group.start_message_index == group.end_message_index {
+                format!("  Msg {}", group.start_message_index + 1)
+            } else {
+                format!(
+                    "  Msg {}-{}",
+                    group.start_message_index + 1,
+                    group.end_message_index + 1
+                )
+            };
+            writeln!(f, "{}: {}", prefix, group)?;
+        }
+
+        Ok(())
+    }
+}

--- a/nexrad-decode/src/summarize/rda.rs
+++ b/nexrad-decode/src/summarize/rda.rs
@@ -1,0 +1,103 @@
+/// Contains summary information from the RDA Status Data message
+#[derive(Clone, PartialEq, Debug)]
+pub struct RDAStatusInfo {
+    pub rda_status: String,
+    pub operability_status: String,
+    pub control_status: String,
+    pub operational_mode: String,
+    pub vcp_number: Option<i16>,
+    pub vcp_is_local: bool,
+    pub average_transmitter_power: u16,
+    pub reflectivity_calibration: f32,
+    pub super_resolution_status: String,
+    pub data_transmission_enabled: Vec<String>,
+    pub has_alarms: bool,
+    pub active_alarms: Vec<String>,
+    pub scan_data_info: Vec<String>,
+}
+
+/// Helper function to extract RDA status information from a message
+pub fn extract_rda_status_info(
+    message: &crate::messages::rda_status_data::Message,
+) -> RDAStatusInfo {
+    let mut info = RDAStatusInfo {
+        rda_status: format!("{:?}", message.rda_status()),
+        operability_status: format!("{:?}", message.operability_status()),
+        control_status: format!("{:?}", message.control_status()),
+        operational_mode: format!("{:?}", message.operational_mode()),
+        vcp_number: message.volume_coverage_pattern().map(|vcp| vcp.number()),
+        vcp_is_local: message
+            .volume_coverage_pattern()
+            .map(|vcp| vcp.local())
+            .unwrap_or(false),
+        average_transmitter_power: message.average_transmitter_power,
+        reflectivity_calibration: message.horizontal_reflectivity_calibration_correction(),
+        super_resolution_status: format!("{:?}", message.super_resolution_status()),
+        data_transmission_enabled: Vec::new(),
+        has_alarms: !message.rda_alarm_summary().none(),
+        active_alarms: Vec::new(),
+        scan_data_info: Vec::new(),
+    };
+
+    // Data transmission enabled
+    let data_enabled = message.data_transmission_enabled();
+    if data_enabled.none() {
+        info.data_transmission_enabled.push("None".to_string());
+    } else {
+        if data_enabled.reflectivity() {
+            info.data_transmission_enabled
+                .push("Reflectivity".to_string());
+        }
+        if data_enabled.velocity() {
+            info.data_transmission_enabled.push("Velocity".to_string());
+        }
+        if data_enabled.spectrum_width() {
+            info.data_transmission_enabled
+                .push("Spectrum Width".to_string());
+        }
+    }
+
+    // Scan data flags
+    let flags = message.rda_scan_and_data_flags();
+    if flags.avset_enabled() {
+        info.scan_data_info.push("AVSET enabled".to_string());
+    } else {
+        info.scan_data_info.push("AVSET disabled".to_string());
+    }
+    if flags.ebc_enabled() {
+        info.scan_data_info.push("EBC enabled".to_string());
+    }
+    if flags.rda_log_data_enabled() {
+        info.scan_data_info.push("Log data enabled".to_string());
+    }
+    if flags.time_series_data_recording_enabled() {
+        info.scan_data_info
+            .push("Time series recording enabled".to_string());
+    }
+
+    // Alarms
+    let alarms = message.rda_alarm_summary();
+    if alarms.tower_utilities() {
+        info.active_alarms.push("Tower/utilities".to_string());
+    }
+    if alarms.pedestal() {
+        info.active_alarms.push("Pedestal".to_string());
+    }
+    if alarms.transmitter() {
+        info.active_alarms.push("Transmitter".to_string());
+    }
+    if alarms.receiver() {
+        info.active_alarms.push("Receiver".to_string());
+    }
+    if alarms.rda_control() {
+        info.active_alarms.push("RDA control".to_string());
+    }
+    if alarms.communication() {
+        info.active_alarms.push("Communication".to_string());
+    }
+    if alarms.signal_processor() {
+        info.active_alarms.push("Signal processor".to_string());
+    }
+
+    info
+}

--- a/nexrad-decode/src/summarize/vcp.rs
+++ b/nexrad-decode/src/summarize/vcp.rs
@@ -1,0 +1,106 @@
+/// Contains summary information from the Volume Coverage Pattern message
+#[derive(Clone, PartialEq, Debug)]
+pub struct VCPInfo {
+    pub pattern_number: u16,
+    pub version: u8,
+    pub number_of_elevation_cuts: u16,
+    pub pulse_width: String,
+    pub doppler_velocity_resolution: Option<f64>,
+    pub vcp_features: Vec<String>,
+    pub elevations: Vec<VCPElevationInfo>,
+}
+
+/// Summary information about a single elevation cut in a VCP
+#[derive(Clone, PartialEq, Debug)]
+pub struct VCPElevationInfo {
+    pub elevation_angle: f64,
+    pub channel_configuration: String,
+    pub waveform_type: String,
+    pub azimuth_rate: f64,
+    pub super_resolution_features: Vec<String>,
+    pub special_cut_type: Option<String>,
+}
+
+/// Helper function to extract Volume Coverage Pattern information from a message
+pub fn extract_vcp_info(message: &crate::messages::volume_coverage_pattern::Message) -> VCPInfo {
+    let mut vcp_features = Vec::new();
+
+    if message.header.vcp_supplemental_data_sails_vcp() {
+        let sails_cuts = message.header.vcp_supplemental_data_number_sails_cuts();
+        vcp_features.push(format!("SAILS ({} cuts)", sails_cuts));
+    }
+
+    if message.header.vcp_supplemental_data_mrle_vcp() {
+        let mrle_cuts = message.header.vcp_supplemental_data_number_mrle_cuts();
+        vcp_features.push(format!("MRLE ({} cuts)", mrle_cuts));
+    }
+
+    if message.header.vcp_supplemental_data_mpda_vcp() {
+        vcp_features.push("MPDA".to_string());
+    }
+
+    if message.header.vcp_supplemental_data_base_tilt_vcp() {
+        let base_tilts = message.header.vcp_supplemental_data_base_tilts();
+        vcp_features.push(format!("Base tilts ({} cuts)", base_tilts));
+    }
+
+    if message.header.vcp_sequencing_sequence_active() {
+        vcp_features.push("VCP sequence active".to_string());
+    }
+
+    if message.header.vcp_sequencing_truncated_vcp() {
+        vcp_features.push("Truncated VCP".to_string());
+    }
+
+    let mut elevations = Vec::new();
+    for elev in &message.elevations {
+        let mut super_res_features = Vec::new();
+        if elev.super_resolution_control_half_degree_azimuth() {
+            super_res_features.push("0.5° azimuth".to_string());
+        }
+        if elev.super_resolution_control_quarter_km_reflectivity() {
+            super_res_features.push("0.25 km reflectivity".to_string());
+        }
+        if elev.super_resolution_control_doppler_to_300km() {
+            super_res_features.push("Doppler to 300 km".to_string());
+        }
+        if elev.super_resolution_control_dual_polarization_to_300km() {
+            super_res_features.push("Dual pol to 300 km".to_string());
+        }
+
+        // Determine special cut type
+        let mut special_cut_type = None;
+        if elev.supplemental_data_sails_cut() {
+            let seq = elev.supplemental_data_sails_sequence_number();
+            special_cut_type = Some(format!("SAILS {}", seq));
+        } else if elev.supplemental_data_mrle_cut() {
+            let seq = elev.supplemental_data_mrle_sequence_number();
+            special_cut_type = Some(format!("MRLE {}", seq));
+        } else if elev.supplemental_data_mpda_cut() {
+            special_cut_type = Some("MPDA".to_string());
+        } else if elev.supplemental_data_base_tilt_cut() {
+            special_cut_type = Some("Base tilt".to_string());
+        }
+
+        elevations.push(VCPElevationInfo {
+            elevation_angle: elev.elevation_angle_degrees(),
+            channel_configuration: format!("{:?}", elev.channel_configuration()),
+            waveform_type: format!("{:?}", elev.waveform_type()),
+            azimuth_rate: elev.azimuth_rate_degrees_per_second(),
+            super_resolution_features: super_res_features,
+            special_cut_type,
+        });
+    }
+
+    VCPInfo {
+        pattern_number: message.header.pattern_number,
+        version: message.header.version,
+        number_of_elevation_cuts: message.header.number_of_elevation_cuts,
+        pulse_width: format!("{:?}", message.header.pulse_width()),
+        doppler_velocity_resolution: message
+            .header
+            .doppler_velocity_resolution_meters_per_second(),
+        vcp_features,
+        elevations,
+    }
+}


### PR DESCRIPTION
This makes some upgrades to the message summarization output so it's easier to understand and more detailed.

Example:
```
    Scans from 2022-03-05 23:23:25.394 UTC to 2022-03-05 23:29:55.397 UTC (6.50m)
    VCPs: VCP212
    Messages:
      Msg 1-5: RDAClutterFilterMap (5), Time: 2022-03-04 20:32:22.975
      Msg 6-126: Unknown(0) (121), Time: 1969-12-31 00:00:00.000
      Msg 127-130: RDAAdaptationData (4), Time: 2022-02-17 15:19:06.062
      Msg 131: Unknown(0), Time: 1969-12-31 00:00:00.000
      Msg 132: RDAPerformanceMaintenanceData, Time: 2022-03-05 23:23:25.395
      Msg 133: VCP: #212, Version: 1
        23 elevation cuts, Pulse width: Short, Doppler resolution: 0.5 m/s
        Features: MRLE (3 cuts)
        Elevation cuts:
          Cut #1: 0.48°, CS, SZ2Phase, 21.1°/s, Super res: 0.5° azimuth, 0.25 km reflectivity, Dual pol to 300 km
          Cut #2: 0.48°, CDW, SZ2Phase, 15.8°/s, Super res: 0.5° azimuth, 0.25 km reflectivity, Doppler to 300 km
          Cut #3: 0.88°, CS, SZ2Phase, 21.1°/s, Super res: 0.5° azimuth, 0.25 km reflectivity, Dual pol to 300 km
          Cut #4: 0.88°, CDW, SZ2Phase, 15.8°/s, Super res: 0.5° azimuth, 0.25 km reflectivity, Doppler to 300 km
          Cut #5: 1.32°, CS, SZ2Phase, 23.0°/s, Super res: 0.5° azimuth, 0.25 km reflectivity, Dual pol to 300 km
          Cut #6: 1.32°, CDW, SZ2Phase, 15.8°/s, Super res: 0.5° azimuth, 0.25 km reflectivity, Doppler to 300 km
          Cut #7: 1.80°, B, ConstantPhase, 26.4°/s, Super res: 0.25 km reflectivity, Doppler to 300 km, Dual pol to 300 km
          Cut #8: 2.42°, B, ConstantPhase, 27.3°/s, Super res: 0.25 km reflectivity, Doppler to 300 km, Dual pol to 300 km
          Cut #9: 3.12°, B, ConstantPhase, 28.2°/s, Super res: 0.25 km reflectivity, Doppler to 300 km, Dual pol to 300 km
          Cut #10: 4.00°, B, ConstantPhase, 26.4°/s, Super res: 0.25 km reflectivity, Doppler to 300 km, Dual pol to 300 km
          Cut #11: 5.10°, B, ConstantPhase, 26.4°/s, Super res: 0.25 km reflectivity, Doppler to 300 km, Dual pol to 300 km
          Cut #12: 0.48° (MRLE 1), CS, SZ2Phase, 21.1°/s, Super res: 0.5° azimuth, 0.25 km reflectivity, Dual pol to 300 km
          Cut #13: 0.48° (MRLE 1), CDW, SZ2Phase, 15.8°/s, Super res: 0.5° azimuth, 0.25 km reflectivity, Doppler to 300 km
          Cut #14: 0.88° (MRLE 2), CS, SZ2Phase, 21.1°/s, Super res: 0.5° azimuth, 0.25 km reflectivity, Dual pol to 300 km
          Cut #15: 0.88° (MRLE 2), CDW, SZ2Phase, 15.8°/s, Super res: 0.5° azimuth, 0.25 km reflectivity, Doppler to 300 km
          Cut #16: 1.32° (MRLE 3), CS, SZ2Phase, 23.0°/s, Super res: 0.5° azimuth, 0.25 km reflectivity, Dual pol to 300 km
          Cut #17: 1.32° (MRLE 3), CDW, SZ2Phase, 15.8°/s, Super res: 0.5° azimuth, 0.25 km reflectivity, Doppler to 300 km
          Cut #18: 6.42°, B, ConstantPhase, 26.4°/s, Super res: 0.25 km reflectivity, Doppler to 300 km, Dual pol to 300 km
          Cut #19: 8.00°, CDWO, ConstantPhase, 28.4°/s, Super res: 0.25 km reflectivity, Dual pol to 300 km
          Cut #20: 10.02°, CDWO, ConstantPhase, 28.4°/s, Super res: 0.25 km reflectivity, Dual pol to 300 km
          Cut #21: 12.48°, CDWO, ConstantPhase, 28.7°/s, Super res: 0.25 km reflectivity, Dual pol to 300 km
          Cut #22: 15.60°, CDWO, ConstantPhase, 28.7°/s, Super res: 0.25 km reflectivity, Dual pol to 300 km
          Cut #23: 19.51°, CDWO, ConstantPhase, 28.7°/s, Super res: 0.25 km reflectivity, Dual pol to 300 km
      Msg 134: RDA Status: Operate, Operability: OnLine
        Control: RemoteControlOnly, Mode: Operational, VCP: 212 (remote)
        Transmitter power: 1371 W, Reflectivity cal: 0.15 dB
        Super resolution: Enabled
        Data enabled: Velocity, Spectrum Width
        Scan settings: AVSET disabled, Log data enabled, Time series recording enabled
      Msg 135-854: Elevation: #1 (0.61°), Azimuth: 155.2° to 154.7°, Time: 23:23:25.395 to 23:23:40.699 (15.30s)
        Data types: REF (720), DP (720), CC (720), KDP (720), ZDR (720)
      Msg 855-1574: Elevation: #2 (0.53°), Azimuth: 177.2° to 176.7°, Time: 23:23:42.787 to 23:24:03.853 (21.07s)
        Data types: VEL (720), REF (720), SW (720)
      Msg 1575-2294: Elevation: #3 (0.84°), Azimuth: 192.2° to 191.7°, Time: 23:24:05.723 to 23:24:21.074 (15.35s)
        Data types: CC (720), DP (720), REF (720), ZDR (720), KDP (720)
      Msg 2295-3014: Elevation: #4 (0.92°), Azimuth: 215.2° to 214.7°, Time: 23:24:23.240 to 23:24:44.298 (21.06s)
        Data types: SW (720), REF (720), VEL (720)
      Msg 3015-3734: Elevation: #5 (1.27°), Azimuth: 233.2° to 232.8°, Time: 23:24:46.347 to 23:25:00.316 (13.97s)
        Data types: KDP (720), CC (720), ZDR (720), REF (720), DP (720)
      Msg 3735-4454: Elevation: #6 (1.36°), Azimuth: 260.2° to 259.7°, Time: 23:25:02.588 to 23:25:23.656 (21.07s)
        Data types: VEL (720), REF (720), SW (720)
      Msg 4455-4814: Elevation: #7 (1.86°), Azimuth: 282.6° to 281.6°, Time: 23:25:25.873 to 23:25:37.899 (12.03s)
        Data types: CC (360), DP (360), REF (360), SW (360), ZDR (360), KDP (360), VEL (360)
      Msg 4815-5174: Elevation: #8 (2.25°), Azimuth: 305.6° to 304.6°, Time: 23:25:39.759 to 23:25:51.351 (11.59s)
        Data types: DP (360), REF (360), SW (360), VEL (360), ZDR (360), KDP (360), CC (360)
      Msg 5175-5279: Elevation: #9 (2.95°), Azimuth: 334.6° to 78.6°, Time: 23:25:53.390 to 23:25:55.908 (2.52s)
        Data types: VEL (105), DP (105), ZDR (105), KDP (105), SW (105), REF (105), CC (105)
      Msg 5280: RDA Status: Operate, Operability: OnLine
        Control: RemoteControlOnly, Mode: Operational, VCP: 212 (remote)
        Transmitter power: 944 W, Reflectivity cal: 0.15 dB
        Super resolution: Enabled
        Data enabled: Velocity, Spectrum Width
        Scan settings: AVSET disabled, Log data enabled, Time series recording enabled
      Msg 5281-5309 (cont.): Elevation: #9 (3.12°), Azimuth: 79.6° to 107.6°, Time: 23:25:55.919 to 23:25:56.877 (0.96s)
        Data types: SW (29), REF (29), ZDR (29), KDP (29), VEL (29), DP (29), CC (29)
      Msg 5310: RDA Status: Operate, Operability: OnLine
        Control: RemoteControlOnly, Mode: Operational, VCP: 212 (remote)
        Transmitter power: 980 W, Reflectivity cal: 0.15 dB
        Super resolution: Enabled
        Data enabled: Velocity, Spectrum Width
        Scan settings: AVSET disabled, Log data enabled, Time series recording enabled
      Msg 5311-5536 (cont.): Elevation: #9 (3.12°), Azimuth: 108.6° to 333.6°, Time: 23:25:56.928 to 23:26:04.546 (7.62s)
        Data types: CC (226), ZDR (226), KDP (226), REF (226), VEL (226), DP (226), SW (226)
      Msg 5537-5896: Elevation: #10 (3.85°), Azimuth: 1.6° to 0.6°, Time: 23:26:06.523 to 23:26:18.547 (12.02s)
        Data types: KDP (360), SW (360), ZDR (360), DP (360), CC (360), VEL (360), REF (360)
      Msg 5897-6256: Elevation: #11 (4.91°), Azimuth: 28.6° to 27.6°, Time: 23:26:20.574 to 23:26:32.604 (12.03s)
        Data types: SW (360), REF (360), KDP (360), ZDR (360), DP (360), VEL (360), CC (360)
      Msg 6257-6976: Elevation: #12 (0.27°), Azimuth: 75.2° to 74.8°, Time: 23:26:35.242 to 23:26:50.916 (15.67s)
        Data types: REF (720), ZDR (720), KDP (720), CC (720), DP (720)
      Msg 6977-7696: Elevation: #13 (0.53°), Azimuth: 97.2° to 96.7°, Time: 23:26:53.015 to 23:27:14.077 (21.06s)
        Data types: VEL (720), REF (720), SW (720)
      Msg 7697-8416: Elevation: #14 (0.76°), Azimuth: 111.2° to 110.7°, Time: 23:27:15.927 to 23:27:31.273 (15.35s)
        Data types: KDP (720), REF (720), ZDR (720), DP (720), CC (720)
      Msg 8417-9136: Elevation: #15 (0.92°), Azimuth: 134.2° to 133.7°, Time: 23:27:33.421 to 23:27:54.487 (21.07s)
        Data types: REF (720), VEL (720), SW (720)
      Msg 9137-9856: Elevation: #16 (1.27°), Azimuth: 150.2° to 149.8°, Time: 23:27:56.419 to 23:28:10.397 (13.98s)
        Data types: ZDR (720), REF (720), CC (720), DP (720), KDP (720)
      Msg 9857-10576: Elevation: #17 (1.36°), Azimuth: 177.2° to 176.7°, Time: 23:28:12.684 to 23:28:33.736 (21.05s)
        Data types: VEL (720), SW (720), REF (720)
      Msg 10577-10936: Elevation: #18 (6.28°), Azimuth: 214.6° to 213.6°, Time: 23:28:36.471 to 23:28:48.497 (12.03s)
        Data types: SW (360), VEL (360), CC (360), ZDR (360), DP (360), KDP (360), REF (360)
      Msg 10937-11296: Elevation: #19 (7.83°), Azimuth: 246.5° to 245.5°, Time: 23:28:50.661 to 23:29:01.757 (11.10s)
        Data types: REF (360), SW (360), ZDR (360), DP (360), CC (360), VEL (360), KDP (360)
      Msg 11297-11656: Elevation: #20 (9.88°), Azimuth: 281.5° to 280.5°, Time: 23:29:03.962 to 23:29:15.015 (11.05s)
        Data types: VEL (360), ZDR (360), SW (360), REF (360), DP (360), KDP (360), CC (360)
      Msg 11657-12016: Elevation: #21 (12.32°), Azimuth: 321.5° to 320.5°, Time: 23:29:17.423 to 23:29:28.342 (10.92s)
        Data types: KDP (360), CC (360), SW (360), VEL (360), DP (360), REF (360), ZDR (360)
      Msg 12017-12376: Elevation: #22 (15.41°), Azimuth: 6.5° to 5.5°, Time: 23:29:30.874 to 23:29:41.792 (10.92s)
        Data types: REF (360), ZDR (360), DP (360), VEL (360), SW (360), CC (360), KDP (360)
      Msg 12377-12736: Elevation: #23 (19.39°), Azimuth: 55.5° to 54.5°, Time: 23:29:44.473 to 23:29:55.397 (10.92s)
        Data types: CC (360), SW (360), DP (360), VEL (360), ZDR (360), KDP (360), REF (360)

```