### PR TITLE
Improve `ChunkIdentifier` by reducing dependence on name format

### DIFF
--- a/nexrad-data/examples/chunk_timing.rs
+++ b/nexrad-data/examples/chunk_timing.rs
@@ -76,11 +76,11 @@ async fn main() -> Result<()> {
 
     // Sort chunks by modified time
     chunks.sort_by(|a, b| {
-        if let (Some(time_a), Some(time_b)) = (a.date_time(), b.date_time()) {
+        if let (Some(time_a), Some(time_b)) = (a.upload_date_time(), b.upload_date_time()) {
             time_a.cmp(&time_b)
-        } else if a.date_time().is_some() {
+        } else if a.upload_date_time().is_some() {
             Ordering::Less
-        } else if b.date_time().is_some() {
+        } else if b.upload_date_time().is_some() {
             Ordering::Greater
         } else {
             Ordering::Equal
@@ -119,7 +119,7 @@ async fn main() -> Result<()> {
 
     for chunk_id in chunks_to_analyze {
         let chunk_name = chunk_id.name();
-        let modified_time = chunk_id.date_time();
+        let modified_time = chunk_id.upload_date_time();
 
         // Calculate time difference
         let time_diff = if let Some(time) = modified_time {

--- a/nexrad-data/examples/latency_analysis.rs
+++ b/nexrad-data/examples/latency_analysis.rs
@@ -204,7 +204,7 @@ async fn main() -> Result<()> {
                 }
             }
 
-            last_chunk_time = chunk_id.date_time();
+            last_chunk_time = chunk_id.upload_date_time();
 
             downloaded_chunk_count += 1;
             if downloaded_chunk_count >= desired_chunk_count {
@@ -260,7 +260,7 @@ fn process_record(
     let rounded_download_time = download_time.round_subsecs(0);
 
     let aws_latency = chunk_id
-        .date_time()
+        .upload_date_time()
         .map(|time| {
             if rounded_download_time < time {
                 warn!("Download time is before S3 modified time: download={}, rounded download={}, s3={}", download_time, rounded_download_time, time);
@@ -271,7 +271,7 @@ fn process_record(
         .unwrap_or(f64::NAN);
 
     // Compare chunk_id.date_time() with last_chunk_time, though either could be None
-    let time_since_last_chunk = match (chunk_id.date_time(), last_chunk_time) {
+    let time_since_last_chunk = match (chunk_id.upload_date_time(), last_chunk_time) {
         (Some(current), Some(last)) => {
             format!("{}", (current - last).num_milliseconds() as f64 / 1000.0)
         }

--- a/nexrad-data/examples/realtime.rs
+++ b/nexrad-data/examples/realtime.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
             info!(
                 "Downloaded chunk {} from {:?} at {:?} of size {}",
                 chunk_id.name(),
-                chunk_id.date_time(),
+                chunk_id.upload_date_time(),
                 Utc::now(),
                 chunk.data().len()
             );
@@ -144,7 +144,7 @@ fn decode_record(
             .latest_collection_time
             .map(|time| (download_time - time).num_milliseconds() as f64 / 1000.0),
         chunk_id
-            .date_time()
+            .upload_date_time()
             .map(|time| (download_time - time).num_milliseconds() as f64 / 1000.0),
     );
 }

--- a/nexrad-data/src/aws/realtime/chunk_identifier.rs
+++ b/nexrad-data/src/aws/realtime/chunk_identifier.rs
@@ -127,18 +127,8 @@ impl ChunkIdentifier {
     /// Identifies the next chunk's expected location.
     #[cfg(feature = "nexrad-decode")]
     pub fn next_chunk(&self, elevation_chunk_mapper: &ElevationChunkMapper) -> Option<NextChunk> {
-        if self.chunk_type == ChunkType::Start {
-            return Some(NextChunk::Sequence(ChunkIdentifier::new(
-                self.site().to_string(),
-                self.volume,
-                self.date_time_prefix,
-                2,
-                ChunkType::Start,
-                None,
-            )));
-        }
-
-        if elevation_chunk_mapper.is_final_sequence(self.sequence) {
+        let final_sequence = elevation_chunk_mapper.final_sequence();
+        if self.sequence == final_sequence {
             return Some(NextChunk::Volume(self.volume.next()));
         }
 
@@ -147,7 +137,11 @@ impl ChunkIdentifier {
             self.volume,
             self.date_time_prefix,
             self.sequence + 1,
-            ChunkType::Intermediate,
+            if self.sequence + 1 == final_sequence {
+                ChunkType::End
+            } else {
+                ChunkType::Intermediate
+            },
             None,
         )))
     }

--- a/nexrad-data/src/aws/realtime/chunk_identifier.rs
+++ b/nexrad-data/src/aws/realtime/chunk_identifier.rs
@@ -1,14 +1,30 @@
-use crate::aws::realtime::{ChunkType, VolumeIndex};
-use chrono::{DateTime, Utc};
+use crate::{
+    aws::realtime::{ChunkType, VolumeIndex},
+    result::{aws::AWSError, Error, Result},
+};
+use chrono::{DateTime, NaiveDateTime, Utc};
+
+#[cfg(feature = "nexrad-decode")]
+use crate::aws::realtime::ElevationChunkMapper;
 
 /// Identifies a volume chunk within the real-time NEXRAD data bucket. These chunks are uploaded
 /// every few seconds and contain a portion of the radar data for a specific volume.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ChunkIdentifier {
+    // These three fields are the same for all chunks in a volume
     site: String,
     volume: VolumeIndex,
+    date_time_prefix: NaiveDateTime,
+
+    // These fields identify a specific chunk within the volume
+    sequence: usize,
+    chunk_type: ChunkType,
+
+    // This is derived from the other fields
     name: String,
-    date_time: Option<DateTime<Utc>>,
+
+    // If this chunk was downloaded, this is the upload time
+    upload_date_time: Option<DateTime<Utc>>,
 }
 
 impl ChunkIdentifier {
@@ -16,15 +32,61 @@ impl ChunkIdentifier {
     pub fn new(
         site: String,
         volume: VolumeIndex,
-        name: String,
-        date_time: Option<DateTime<Utc>>,
+        date_time_prefix: NaiveDateTime,
+        sequence: usize,
+        chunk_type: ChunkType,
+        upload_date_time: Option<DateTime<Utc>>,
     ) -> Self {
+        let name = format!(
+            "{}-{:03}-{}",
+            date_time_prefix.format("%Y%m%d-%H%M%S"),
+            sequence,
+            chunk_type.abbreviation()
+        );
+
         Self {
             site,
             volume,
+            date_time_prefix,
+            sequence,
+            chunk_type,
             name,
-            date_time,
+            upload_date_time,
         }
+    }
+
+    /// Creates a new chunk identifier by parsing a chunk name.
+    pub fn from_name(
+        site: String,
+        volume: VolumeIndex,
+        name: String,
+        upload_date_time: Option<DateTime<Utc>>,
+    ) -> Result<Self> {
+        let date_time_prefix = name[..15]
+            .parse::<NaiveDateTime>()
+            .map_err(|_| Error::AWS(AWSError::UnrecognizedChunkDateTime(name[..15].to_string())))?;
+
+        let sequence = name[15..18].parse::<usize>().map_err(|_| {
+            Error::AWS(AWSError::UnrecognizedChunkSequence(
+                name[15..18].to_string(),
+            ))
+        })?;
+
+        let chunk_type = ChunkType::from_abbreviation(
+            name.chars()
+                .last()
+                .ok_or(Error::AWS(AWSError::UnrecognizedChunkType(None)))?,
+        )?;
+
+        Ok(Self {
+            site,
+            volume,
+            date_time_prefix,
+            sequence,
+            chunk_type,
+            name,
+            upload_date_time,
+        })
     }
 
     /// The chunk's radar site identifier.
@@ -37,59 +99,55 @@ impl ChunkIdentifier {
         &self.volume
     }
 
+    /// The chunk's date and time prefix, consistent across all chunks in a volume.
+    pub fn date_time_prefix(&self) -> &NaiveDateTime {
+        &self.date_time_prefix
+    }
+
+    /// The sequence number of this chunk within the volume.
+    pub fn sequence(&self) -> usize {
+        self.sequence
+    }
+
+    /// The chunk's type.
+    pub fn chunk_type(&self) -> ChunkType {
+        self.chunk_type
+    }
+
     /// The chunk's name.
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    /// The chunk's name prefix.
-    pub fn name_prefix(&self) -> &str {
-        &self.name[..15]
-    }
-
-    /// The sequence number of this chunk within the volume.
-    pub fn sequence(&self) -> Option<usize> {
-        self.name.split('-').nth(2).and_then(|s| s.parse().ok())
-    }
-
-    /// The position of this chunk within the volume.
-    pub fn chunk_type(&self) -> Option<ChunkType> {
-        match self.name.chars().last() {
-            Some('S') => Some(ChunkType::Start),
-            Some('I') => Some(ChunkType::Intermediate),
-            Some('E') => Some(ChunkType::End),
-            _ => None,
-        }
-    }
-
     /// The date and time this chunk was uploaded.
-    pub fn date_time(&self) -> Option<DateTime<Utc>> {
-        self.date_time
+    pub fn upload_date_time(&self) -> Option<DateTime<Utc>> {
+        self.upload_date_time
     }
 
     /// Identifies the next chunk's expected location.
     #[cfg(feature = "nexrad-decode")]
-    pub fn next_chunk(
-        &self,
-        elevation_chunk_mapper: &crate::aws::realtime::ElevationChunkMapper,
-    ) -> Option<NextChunk> {
-        if self.chunk_type() == Some(ChunkType::Start) {
+    pub fn next_chunk(&self, elevation_chunk_mapper: &ElevationChunkMapper) -> Option<NextChunk> {
+        if self.chunk_type == ChunkType::Start {
             return Some(NextChunk::Sequence(ChunkIdentifier::new(
                 self.site().to_string(),
                 self.volume,
-                format!("{}-{:03}-{}", self.name_prefix(), 2, "S"),
+                self.date_time_prefix,
+                2,
+                ChunkType::Start,
                 None,
             )));
         }
 
-        if elevation_chunk_mapper.is_final_sequence(self.sequence()?) {
+        if elevation_chunk_mapper.is_final_sequence(self.sequence) {
             return Some(NextChunk::Volume(self.volume.next()));
         }
 
         Some(NextChunk::Sequence(ChunkIdentifier::new(
             self.site().to_string(),
             self.volume,
-            format!("{}-{:03}-{}", self.name_prefix(), self.sequence()? + 1, "I"),
+            self.date_time_prefix,
+            self.sequence + 1,
+            ChunkType::Intermediate,
             None,
         )))
     }

--- a/nexrad-data/src/aws/realtime/chunk_identifier.rs
+++ b/nexrad-data/src/aws/realtime/chunk_identifier.rs
@@ -62,13 +62,13 @@ impl ChunkIdentifier {
         name: String,
         upload_date_time: Option<DateTime<Utc>>,
     ) -> Result<Self> {
-        let date_time_prefix = name[..15]
-            .parse::<NaiveDateTime>()
+        let date_time_prefix = NaiveDateTime::parse_from_str(&name[..15], "%Y%m%d-%H%M%S")
             .map_err(|_| Error::AWS(AWSError::UnrecognizedChunkDateTime(name[..15].to_string())))?;
 
-        let sequence = name[15..18].parse::<usize>().map_err(|_| {
+        let sequence_str = &name[16..19];
+        let sequence = sequence_str.parse::<usize>().map_err(|_| {
             Error::AWS(AWSError::UnrecognizedChunkSequence(
-                name[15..18].to_string(),
+                sequence_str.to_string(),
             ))
         })?;
 

--- a/nexrad-data/src/aws/realtime/chunk_type.rs
+++ b/nexrad-data/src/aws/realtime/chunk_type.rs
@@ -1,7 +1,30 @@
+use crate::result::{aws::AWSError, Error, Result};
+
 /// The position of this chunk within the volume.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum ChunkType {
     Start,
     Intermediate,
     End,
+}
+
+impl ChunkType {
+    /// Creates a new chunk type from an abbreviation.
+    pub fn from_abbreviation(c: char) -> Result<Self> {
+        match c {
+            'S' => Ok(ChunkType::Start),
+            'I' => Ok(ChunkType::Intermediate),
+            'E' => Ok(ChunkType::End),
+            _ => Err(Error::AWS(AWSError::UnrecognizedChunkType(Some(c)))),
+        }
+    }
+
+    /// Returns the abbreviation for this chunk type.
+    pub fn abbreviation(&self) -> char {
+        match self {
+            ChunkType::Start => 'S',
+            ChunkType::Intermediate => 'I',
+            ChunkType::End => 'E',
+        }
+    }
 }

--- a/nexrad-data/src/aws/realtime/download_chunk.rs
+++ b/nexrad-data/src/aws/realtime/download_chunk.rs
@@ -16,12 +16,12 @@ pub async fn download_chunk<'a>(
     let downloaded_object = download_object(REALTIME_BUCKET, &key).await?;
 
     Ok((
-        ChunkIdentifier::new(
+        ChunkIdentifier::from_name(
             site.to_string(),
             *chunk_id.volume(),
             chunk_id.name().to_string(),
             downloaded_object.metadata.last_modified,
-        ),
+        )?,
         Chunk::new(downloaded_object.data)?,
     ))
 }

--- a/nexrad-data/src/aws/realtime/elevation_chunk_mapper.rs
+++ b/nexrad-data/src/aws/realtime/elevation_chunk_mapper.rs
@@ -46,10 +46,11 @@ impl ElevationChunkMapper {
             .map(|elevation_index| elevation_index + 1)
     }
 
-    /// Whether the given sequence number is the final chunk for the volume.
-    pub fn is_final_sequence(&self, sequence: usize) -> bool {
+    /// Returns the final sequence number for the volume.
+    pub fn final_sequence(&self) -> usize {
         self.elevation_chunk_mappings
             .last()
-            .is_some_and(|(_, end)| sequence >= *end)
+            .map(|(_, end)| *end)
+            .unwrap_or(0)
     }
 }

--- a/nexrad-data/src/aws/realtime/estimate_next_chunk_time.rs
+++ b/nexrad-data/src/aws/realtime/estimate_next_chunk_time.rs
@@ -35,33 +35,31 @@ pub fn estimate_chunk_processing_time(
     elevation_chunk_mapper: &ElevationChunkMapper,
     timing_stats: Option<&ChunkTimingStats>,
 ) -> Option<ChronoDuration> {
-    if chunk.chunk_type() == Some(ChunkType::Start) {
+    if chunk.chunk_type() == ChunkType::Start {
         return Some(ChronoDuration::seconds(10));
     }
 
-    if let (Some(sequence), Some(chunk_type)) = (chunk.sequence(), chunk.chunk_type()) {
-        if let Some(elevation) = elevation_chunk_mapper
-            .get_sequence_elevation_number(sequence)
-            .and_then(|elevation_number| vcp.elevations.get(elevation_number - 1))
-        {
-            let waveform_type = elevation.waveform_type();
-            let channel_config = elevation.channel_configuration();
+    if let Some(elevation) = elevation_chunk_mapper
+        .get_sequence_elevation_number(chunk.sequence())
+        .and_then(|elevation_number| vcp.elevations.get(elevation_number - 1))
+    {
+        let waveform_type = elevation.waveform_type();
+        let channel_config = elevation.channel_configuration();
 
-            let characteristics = ChunkCharacteristics {
-                chunk_type,
-                waveform_type,
-                channel_configuration: channel_config,
-            };
+        let characteristics = ChunkCharacteristics {
+            chunk_type: chunk.chunk_type(),
+            waveform_type,
+            channel_configuration: channel_config,
+        };
 
-            let average_timing =
-                timing_stats.and_then(|stats| stats.get_average_timing(&characteristics));
-            let average_attempts =
-                timing_stats.and_then(|stats| stats.get_average_attempts(&characteristics));
+        let average_timing =
+            timing_stats.and_then(|stats| stats.get_average_timing(&characteristics));
+        let average_attempts =
+            timing_stats.and_then(|stats| stats.get_average_attempts(&characteristics));
 
-            // Check if we have historical timing data for this combination
-            let estimated_wait_time = if let (Some(avg_timing), Some(avg_attempts)) =
-                (average_timing, average_attempts)
-            {
+        // Check if we have historical timing data for this combination
+        let estimated_wait_time =
+            if let (Some(avg_timing), Some(avg_attempts)) = (average_timing, average_attempts) {
                 // Use historical average if available
                 let mut wait_time = avg_timing;
 
@@ -88,8 +86,7 @@ pub fn estimate_chunk_processing_time(
                 wait_time
             };
 
-            return Some(estimated_wait_time);
-        }
+        return Some(estimated_wait_time);
     }
 
     None

--- a/nexrad-data/src/aws/realtime/get_latest_volume.rs
+++ b/nexrad-data/src/aws/realtime/get_latest_volume.rs
@@ -15,7 +15,7 @@ pub async fn get_latest_volume(site: &str) -> crate::result::Result<LatestVolume
         calls.fetch_add(1, Relaxed);
         async move {
             let chunks = list_chunks_in_volume(site, VolumeIndex::new(volume + 1), 1).await?;
-            Ok(chunks.first().and_then(|chunk| chunk.date_time()))
+            Ok(chunks.first().and_then(|chunk| chunk.upload_date_time()))
         }
     })
     .await

--- a/nexrad-data/src/aws/realtime/list_chunks_in_volume.rs
+++ b/nexrad-data/src/aws/realtime/list_chunks_in_volume.rs
@@ -20,9 +20,9 @@ pub async fn list_chunks_in_volume(
                 .unwrap_or_else(|| object.key.as_ref())
                 .to_string();
 
-            ChunkIdentifier::new(site.to_string(), volume, identifier, object.last_modified)
+            ChunkIdentifier::from_name(site.to_string(), volume, identifier, object.last_modified)
         })
-        .collect();
+        .collect::<crate::result::Result<Vec<_>>>()?;
 
     Ok(metas)
 }

--- a/nexrad-data/src/result.rs
+++ b/nexrad-data/src/result.rs
@@ -50,6 +50,12 @@ pub mod aws {
         InvalidSiteIdentifier(String),
         #[error("chunk data in unrecognized format")]
         UnrecognizedChunkFormat,
+        #[error("unrecognized chunk date time")]
+        UnrecognizedChunkDateTime(String),
+        #[error("unrecognized chunk sequence")]
+        UnrecognizedChunkSequence(String),
+        #[error("unrecognized chunk type")]
+        UnrecognizedChunkType(Option<char>),
         #[error("error listing AWS S3 objects")]
         S3ListObjectsError(reqwest::Error),
         #[error("error requesting AWS S3 object")]


### PR DESCRIPTION
The `ChunkIdentifier` is coupled to the particular string format, which makes manual construction of chunk IDs awkward and brittle. This refactors the ID to deal with the underlying fields more directly.