### PR TITLE
Add record summary information to list view

### DIFF
--- a/nexrad-inspector/src/app.rs
+++ b/nexrad-inspector/src/app.rs
@@ -889,12 +889,15 @@ impl App {
                 let msg_type = header.message_type();
                 if matches!(
                     msg_type,
-                    MessageType::RDADigitalRadarData | MessageType::RDADigitalRadarDataGenericFormat
+                    MessageType::RDADigitalRadarData
+                        | MessageType::RDADigitalRadarDataGenericFormat
                 ) {
                     // Parse the message to get detailed radar data
                     if let Ok(parsed_messages) = decode_messages(&msg.data) {
                         if let Some(parsed_msg) = parsed_messages.first() {
-                            if let MessageContents::DigitalRadarData(digital_radar_data) = parsed_msg.contents() {
+                            if let MessageContents::DigitalRadarData(digital_radar_data) =
+                                parsed_msg.contents()
+                            {
                                 // Track which products are present
                                 if digital_radar_data.reflectivity_data_block.is_some() {
                                     products.insert("REF");
@@ -905,13 +908,19 @@ impl App {
                                 if digital_radar_data.spectrum_width_data_block.is_some() {
                                     products.insert("SW");
                                 }
-                                if digital_radar_data.differential_reflectivity_data_block.is_some() {
+                                if digital_radar_data
+                                    .differential_reflectivity_data_block
+                                    .is_some()
+                                {
                                     products.insert("ZDR");
                                 }
                                 if digital_radar_data.differential_phase_data_block.is_some() {
                                     products.insert("PHI");
                                 }
-                                if digital_radar_data.correlation_coefficient_data_block.is_some() {
+                                if digital_radar_data
+                                    .correlation_coefficient_data_block
+                                    .is_some()
+                                {
                                     products.insert("RHO");
                                 }
                                 if digital_radar_data.specific_diff_phase_data_block.is_some() {
@@ -925,7 +934,8 @@ impl App {
 
                                 // Track elevation
                                 if elevation.is_none() {
-                                    elevation = Some(digital_radar_data.header.elevation_angle.get());
+                                    elevation =
+                                        Some(digital_radar_data.header.elevation_angle.get());
                                 }
                             }
                         }

--- a/nexrad-inspector/src/ui/file_view.rs
+++ b/nexrad-inspector/src/ui/file_view.rs
@@ -101,9 +101,19 @@ fn render_record_list(frame: &mut Frame, app: &App, area: Rect) {
 
             let (record_type, products, elevation, azimuth) =
                 if let Some(summary) = app.get_record_summary(record.index) {
-                    (summary.record_type, summary.products, summary.elevation, summary.azimuth)
+                    (
+                        summary.record_type,
+                        summary.products,
+                        summary.elevation,
+                        summary.azimuth,
+                    )
                 } else {
-                    ("-".to_string(), "-".to_string(), "-".to_string(), "-".to_string())
+                    (
+                        "-".to_string(),
+                        "-".to_string(),
+                        "-".to_string(),
+                        "-".to_string(),
+                    )
                 };
 
             let cells = vec![
@@ -121,14 +131,14 @@ fn render_record_list(frame: &mut Frame, app: &App, area: Rect) {
         .collect();
 
     let widths = [
-        Constraint::Length(5),   // #
-        Constraint::Length(12),  // Status
-        Constraint::Length(12),  // Compressed
-        Constraint::Length(12),  // Decompressed
-        Constraint::Length(12),  // Type
-        Constraint::Min(15),     // Products
-        Constraint::Length(10),  // Elevation
-        Constraint::Length(12),  // Azimuth
+        Constraint::Length(5),  // #
+        Constraint::Length(12), // Status
+        Constraint::Length(12), // Compressed
+        Constraint::Length(12), // Decompressed
+        Constraint::Length(12), // Type
+        Constraint::Min(15),    // Products
+        Constraint::Length(10), // Elevation
+        Constraint::Length(12), // Azimuth
     ];
 
     let table = Table::new(rows, widths)


### PR DESCRIPTION
This adds some summary information to the records list view describing the contents of the record. Records typically fall into two types based on the types of messages they contain:

1. Metadata records (RDA status data, clutter filter map, etc)
2. Radar data records (message type 31, digital radar data)

Records which contain only radar data messages should be labeled as "Radar data". They can also include some summary information about their messages, such as which products are included, the azimuth range, and the elevation. In the future we could include other scan parameters like resolution.

Records containing a mix of non-radar data messages should be labeled as "Metadata" and include a parenthesized list of distinct message types.

If a record is found with both metadata and radar data (I've not seen this) we should label it "Mixed" and include a parenthesized list of distinct message types, just like with metadata records.

<img width="1917" height="1046" alt="image" src="https://github.com/user-attachments/assets/6d67793d-9f71-469d-983a-178d6e9d8f4a" />

Closes #49