### PR TITLE
Add filtering for empty/unknown messages

### DIFF
--- a/nexrad-inspector/src/app.rs
+++ b/nexrad-inspector/src/app.rs
@@ -188,6 +188,9 @@ pub struct App {
 
     /// Status message to display
     pub status_message: Option<String>,
+
+    /// Whether to filter out empty/unknown messages in record view
+    pub filter_empty_unknown: bool,
 }
 
 impl App {
@@ -217,6 +220,7 @@ impl App {
             parsed_scroll: 0,
             show_help: false,
             status_message: None,
+            filter_empty_unknown: true,
         }
     }
 
@@ -597,20 +601,38 @@ impl App {
         Ok(self.messages_cache.get(&record_index).unwrap())
     }
 
+    /// Check if a message should be filtered out (empty or unknown)
+    fn should_filter_message(msg: &MessageInfo) -> bool {
+        match Self::get_message_header(&msg.data) {
+            Some(hdr) => matches!(hdr.message_type(), MessageType::Unknown(_)),
+            None => true, // No valid header = empty/unparseable
+        }
+    }
+
+    /// Get messages for display, respecting the filter setting
+    pub fn get_displayed_messages(&mut self, record_index: usize) -> AppResult<Vec<MessageInfo>> {
+        let filter = self.filter_empty_unknown;
+        let messages = self.get_messages(record_index)?;
+        if filter {
+            Ok(messages
+                .iter()
+                .filter(|m| !Self::should_filter_message(m))
+                .cloned()
+                .collect())
+        } else {
+            Ok(messages.to_vec())
+        }
+    }
+
     /// Get the currently selected message data (cloned to avoid borrow issues)
     pub fn current_message_data(&mut self) -> AppResult<Vec<u8>> {
         let record_index = self.selected_record;
         let message_index = self.selected_message;
-        let messages = self.get_messages(record_index)?;
+        let messages = self.get_displayed_messages(record_index)?;
         messages
             .get(message_index)
             .map(|m| m.data.clone())
             .ok_or_else(|| "Message not found".into())
-    }
-
-    /// Get the number of messages in a record (if cached)
-    pub fn message_count(&self, record_index: usize) -> Option<usize> {
-        self.messages_cache.get(&record_index).map(|m| m.len())
     }
 
     /// Get the message header for a message
@@ -665,8 +687,8 @@ impl App {
             }
             View::Record => {
                 let record_index = self.selected_record;
-                if let Some(msg_count) = self.message_count(record_index) {
-                    if self.selected_message < msg_count.saturating_sub(1) {
+                if let Ok(messages) = self.get_displayed_messages(record_index) {
+                    if self.selected_message < messages.len().saturating_sub(1) {
                         self.selected_message += 1;
                     }
                 }
@@ -760,6 +782,12 @@ impl App {
     /// Toggle help overlay
     pub fn toggle_help(&mut self) {
         self.show_help = !self.show_help;
+    }
+
+    /// Toggle filtering of empty/unknown messages
+    pub fn toggle_filter(&mut self) {
+        self.filter_empty_unknown = !self.filter_empty_unknown;
+        self.selected_message = 0;
     }
 
     /// Decompress the currently selected record without entering it

--- a/nexrad-inspector/src/main.rs
+++ b/nexrad-inspector/src/main.rs
@@ -282,6 +282,7 @@ fn handle_inspector_keys(app: &mut App, key: event::KeyEvent) -> AppResult<bool>
         }
         KeyCode::Char('d') => app.decompress_selected(),
         KeyCode::Char('D') => app.decompress_all_records(),
+        KeyCode::Char('u') => app.toggle_filter(),
         KeyCode::PageUp => app.page_up(),
         KeyCode::PageDown => app.page_down(),
         _ => {}

--- a/nexrad-inspector/src/ui/mod.rs
+++ b/nexrad-inspector/src/ui/mod.rs
@@ -71,7 +71,7 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             AppMode::Loading => "Loading...",
             AppMode::Inspector => match app.view {
                 View::File => "q:quit  Enter:open  d:decompress  D:decompress all  s:save  ?:help",
-                View::Record => "q:quit  Enter:open message  s:save record  Esc:back  ?:help",
+                View::Record => "q:quit  Enter:open  u:filter  s:save  Esc:back  ?:help",
                 View::Message => "q:quit  Tab:hex/parsed  s:save message  Esc:back  ?:help",
             },
         };
@@ -109,7 +109,7 @@ fn render_error_overlay(frame: &mut Frame, app: &App, area: Rect) {
 fn render_help_overlay(frame: &mut Frame, area: Rect) {
     // Center the help popup
     let popup_width = 60;
-    let popup_height = 21;
+    let popup_height = 22;
     let popup_area = centered_rect(popup_width, popup_height, area);
 
     // Clear the area behind the popup
@@ -130,6 +130,7 @@ File View:
                   decompressed based on current state)
 
 Record View:
+  u               Toggle unknown/empty filter
   s               Save selected record
 
 Message View:

--- a/nexrad-inspector/src/ui/record_view.rs
+++ b/nexrad-inspector/src/ui/record_view.rs
@@ -38,7 +38,7 @@ fn render_record_info(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_message_list(frame: &mut Frame, app: &mut App, area: Rect) {
-    let messages = match app.get_messages(app.selected_record) {
+    let messages = match app.get_displayed_messages(app.selected_record) {
         Ok(msgs) => msgs,
         Err(e) => {
             let error = Paragraph::new(format!("Error loading messages: {}", e))
@@ -104,13 +104,15 @@ fn render_message_list(frame: &mut Frame, app: &mut App, area: Rect) {
         Constraint::Length(14),
     ];
 
+    let title = if app.filter_empty_unknown {
+        format!(" Messages ({}) [filtered] ", messages.len())
+    } else {
+        format!(" Messages ({}) ", messages.len())
+    };
+
     let table = Table::new(rows, widths)
         .header(header)
-        .block(
-            Block::default()
-                .title(format!(" Messages ({}) ", messages.len()))
-                .borders(Borders::ALL),
-        )
+        .block(Block::default().title(title).borders(Borders::ALL))
         .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
         .highlight_symbol("> ");
 


### PR DESCRIPTION
When scrolling messages in `nexrad-inspector` (particularly in the metadata record), there are lots of empty/unknown messages. We should hide those by default with a keyboard shortcut to unfilter them.