### PR TITLE
Harden against invalid inputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ members = [
     "nexrad-render",
     "nexrad-inspector",
 ]
+exclude = [
+    "nexrad-decode/fuzz",
+    "nexrad-data/fuzz",
+]
 
 [workspace.package]
 authors = ["Daniel Way <contact@danieldway.com>"]

--- a/nexrad-data/examples/archive.rs
+++ b/nexrad-data/examples/archive.rs
@@ -113,7 +113,7 @@ async fn main() -> Result<()> {
 
         trace!("Data file size (bytes): {}", file.data().len());
 
-        let records = file.records();
+        let records = file.records()?;
         debug!(
             "Volume with {} records. Header: {:?}",
             records.len(),

--- a/nexrad-data/examples/chunk_csv.rs
+++ b/nexrad-data/examples/chunk_csv.rs
@@ -322,7 +322,7 @@ fn analyze_chunk(
 
     match chunk {
         Chunk::Start(file) => {
-            for mut record in file.records() {
+            for mut record in file.records()? {
                 if record.compressed() {
                     record = record.decompress()?;
                 }

--- a/nexrad-data/examples/chunk_timing.rs
+++ b/nexrad-data/examples/chunk_timing.rs
@@ -196,7 +196,7 @@ fn decode_chunk(
         Chunk::Start(file) => {
             debug!("Decoding volume start chunk");
             // Process records in the file
-            for mut record in file.records() {
+            for mut record in file.records()? {
                 if record.compressed() {
                     trace!("Decompressing LDM record...");
                     record = record.decompress()?;

--- a/nexrad-data/examples/latency_analysis.rs
+++ b/nexrad-data/examples/latency_analysis.rs
@@ -175,7 +175,7 @@ async fn main() -> Result<()> {
 
             match chunk {
                 Chunk::Start(file) => {
-                    let records = file.records();
+                    let records = file.records().expect("records");
                     debug!(
                         "Volume start chunk with {} records. Header: {:?}",
                         records.len(),

--- a/nexrad-data/examples/realtime.rs
+++ b/nexrad-data/examples/realtime.rs
@@ -86,7 +86,7 @@ async fn main() -> Result<()> {
 
             match chunk {
                 Chunk::Start(file) => {
-                    let records = file.records();
+                    let records = file.records().expect("records");
                     debug!(
                         "Volume start chunk with {} records. Header: {:?}",
                         records.len(),

--- a/nexrad-data/fuzz/.gitignore
+++ b/nexrad-data/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target/
+corpus/
+artifacts/
+coverage/

--- a/nexrad-data/fuzz/Cargo.toml
+++ b/nexrad-data/fuzz/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "nexrad-data-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[workspace]
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+nexrad-data = { path = ".." }
+
+[[bin]]
+name = "split_records"
+path = "fuzz_targets/split_records.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "decompress_record"
+path = "fuzz_targets/decompress_record.rs"
+test = false
+doc = false
+bench = false

--- a/nexrad-data/fuzz/fuzz_targets/decompress_record.rs
+++ b/nexrad-data/fuzz/fuzz_targets/decompress_record.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use nexrad_data::volume::Record;
+
+fuzz_target!(|data: &[u8]| {
+    // Fuzz the record decompression path
+    // This should never panic - only return Ok or Err
+    let record = Record::new(data.to_vec());
+    if record.compressed() {
+        let _ = record.decompress();
+    }
+});

--- a/nexrad-data/fuzz/fuzz_targets/split_records.rs
+++ b/nexrad-data/fuzz/fuzz_targets/split_records.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use nexrad_data::volume::split_compressed_records;
+
+fuzz_target!(|data: &[u8]| {
+    // Fuzz the record splitting entry point
+    // This should never panic - only return Ok or Err
+    let _ = split_compressed_records(data);
+});

--- a/nexrad-data/src/aws/realtime/poll_chunks.rs
+++ b/nexrad-data/src/aws/realtime/poll_chunks.rs
@@ -234,7 +234,7 @@ fn get_latest_vcp(
     latest_metadata: &Chunk<'_>,
 ) -> Result<volume_coverage_pattern::Message<'static>> {
     if let Chunk::Start(file) = latest_metadata {
-        for mut record in file.records() {
+        for mut record in file.records()? {
             if record.compressed() {
                 record = record.decompress()?;
             }

--- a/nexrad-data/src/lib.rs
+++ b/nexrad-data/src/lib.rs
@@ -22,7 +22,7 @@
 //! }
 //!
 //! // Process LDM records
-//! for record in volume.records() {
+//! for record in volume.records()? {
 //!     let decompressed = record.decompress()?;
 //!     let messages = decompressed.messages()?;
 //!     // Process radar messages...

--- a/nexrad-data/src/result.rs
+++ b/nexrad-data/src/result.rs
@@ -26,6 +26,10 @@ pub enum Error {
     MissingCoveragePattern,
     #[error("ldm record decompression error")]
     DecompressionError(#[from] bzip2::Error),
+    #[error("truncated record: expected {expected} bytes, got {actual}")]
+    TruncatedRecord { expected: usize, actual: usize },
+    #[error("invalid record size {size} at offset {offset}")]
+    InvalidRecordSize { size: usize, offset: usize },
 }
 
 #[cfg(feature = "aws")]

--- a/nexrad-data/src/volume/file.rs
+++ b/nexrad-data/src/volume/file.rs
@@ -25,7 +25,9 @@ impl File {
     }
 
     /// The file's LDM records.
-    pub fn records(&self) -> Vec<Record<'_>> {
+    ///
+    /// Returns an error if the record data is truncated or malformed.
+    pub fn records(&self) -> crate::result::Result<Vec<Record<'_>>> {
         split_compressed_records(&self.0[size_of::<Header>()..])
     }
 
@@ -39,7 +41,7 @@ impl File {
 
         let mut coverage_pattern_number = None;
         let mut radials = Vec::new();
-        for mut record in self.records() {
+        for mut record in self.records()? {
             if record.compressed() {
                 record = record.decompress()?;
             }
@@ -74,7 +76,10 @@ impl Debug for File {
         debug.field("header", &self.header());
 
         #[cfg(feature = "nexrad-model")]
-        debug.field("records.len()", &self.records().len());
+        debug.field(
+            "records.len()",
+            &self.records().map(|records| records.len()),
+        );
 
         debug.finish()
     }

--- a/nexrad-data/tests/aws_archive.rs
+++ b/nexrad-data/tests/aws_archive.rs
@@ -295,7 +295,7 @@ async fn test_list_and_download_workflow() {
     assert!(file.data().starts_with(b"AR2"));
 
     // Verify we can get records from the downloaded file
-    let records = file.records();
+    let records = file.records().expect("records");
     assert!(!records.is_empty(), "File should contain records");
 }
 

--- a/nexrad-data/tests/aws_realtime_polling.rs
+++ b/nexrad-data/tests/aws_realtime_polling.rs
@@ -13,7 +13,7 @@ const TEST_NEXRAD_FILE: &[u8] = include_bytes!("../../downloads/KDMX20220305_232
 fn get_test_vcp() -> nexrad_decode::messages::volume_coverage_pattern::Message<'static> {
     let volume_file = nexrad_data::volume::File::new(TEST_NEXRAD_FILE.to_vec());
 
-    for mut record in volume_file.records() {
+    for mut record in volume_file.records().expect("records") {
         if record.compressed() {
             record = record.decompress().unwrap();
         }

--- a/nexrad-data/tests/aws_realtime_types.rs
+++ b/nexrad-data/tests/aws_realtime_types.rs
@@ -350,7 +350,7 @@ fn test_chunk_identifier_next_chunk_intermediate() {
 
     // Get VCP from the file
     let mut vcp = None;
-    for mut record in volume_file.records() {
+    for mut record in volume_file.records().expect("records") {
         if record.compressed() {
             record = record.decompress().unwrap();
         }

--- a/nexrad-data/tests/error_handling.rs
+++ b/nexrad-data/tests/error_handling.rs
@@ -38,7 +38,7 @@ fn test_compressed_data_decode_error() {
     const TEST_NEXRAD_FILE: &[u8] = include_bytes!("../../downloads/KDMX20220305_232324_V06");
 
     let volume = nexrad_data::volume::File::new(TEST_NEXRAD_FILE.to_vec());
-    let records = volume.records();
+    let records = volume.records().expect("records");
     let compressed_record = &records[0];
     assert!(
         compressed_record.compressed(),

--- a/nexrad-data/tests/live_decode.rs
+++ b/nexrad-data/tests/live_decode.rs
@@ -116,7 +116,7 @@ fn decode_volume(site: &str, file_name: &str, file: &volume::File) -> Result<Dec
     let mut has_volume_start = false;
     let mut has_volume_end = false;
 
-    let records: Vec<_> = file.records().into_iter().collect();
+    let records: Vec<_> = file.records().expect("records").into_iter().collect();
     if records.is_empty() {
         return Err("No records found in volume".to_string());
     }

--- a/nexrad-data/tests/malformed_records.rs
+++ b/nexrad-data/tests/malformed_records.rs
@@ -1,0 +1,204 @@
+//! Negative tests for malformed record handling.
+//!
+//! These tests verify that record splitting and decompression functions
+//! gracefully handle invalid, truncated, and corrupted input data.
+
+use nexrad_data::result::Error;
+use nexrad_data::volume::{split_compressed_records, Record};
+
+#[test]
+fn test_split_records_empty() {
+    let result = split_compressed_records(&[]);
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_empty());
+}
+
+#[test]
+fn test_split_records_truncated_size_field() {
+    // Less than 4 bytes available for size field
+    let data = vec![0u8, 0u8];
+    let result = split_compressed_records(&data);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        Error::TruncatedRecord { expected, actual } => {
+            assert_eq!(expected, 4);
+            assert_eq!(actual, 2);
+        }
+        other => panic!("Expected TruncatedRecord error, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_split_records_three_bytes() {
+    // Exactly 3 bytes - still not enough for size field
+    let data = vec![0u8; 3];
+    let result = split_compressed_records(&data);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        Error::TruncatedRecord { .. } => {}
+        other => panic!("Expected TruncatedRecord error, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_split_records_size_exceeds_data() {
+    // Size field claims 1000 bytes, only 10 available
+    let mut data = vec![0u8, 0u8, 0x03, 0xe8]; // 1000 in big-endian
+    data.extend_from_slice(&[0u8; 10]);
+    let result = split_compressed_records(&data);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        Error::TruncatedRecord { expected, actual } => {
+            assert!(expected > actual);
+        }
+        other => panic!("Expected TruncatedRecord error, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_split_records_zero_size() {
+    // Size field is zero - should error to prevent infinite loop
+    let data = vec![0u8, 0u8, 0u8, 0u8, 1u8, 2u8, 3u8, 4u8];
+    let result = split_compressed_records(&data);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        Error::InvalidRecordSize { size, offset } => {
+            assert_eq!(size, 0);
+            assert_eq!(offset, 0);
+        }
+        other => panic!("Expected InvalidRecordSize error, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_split_records_negative_size() {
+    // Size field is negative (high bit set) - should work due to unsigned_abs
+    let data = vec![0xFF, 0xFF, 0xFF, 0xFF]; // -1 in i32
+    let result = split_compressed_records(&data);
+    // This will be interpreted as a very large positive number, causing truncation error
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_decompress_uncompressed_data() {
+    let data = vec![0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8];
+    let record = Record::new(data);
+    assert!(!record.compressed());
+
+    let result = record.decompress();
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        Error::UncompressedDataError => {}
+        other => panic!("Expected UncompressedDataError, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_decompress_invalid_bzip_header() {
+    // Record starts with size prefix but has invalid magic bytes
+    let mut data = vec![0u8, 0u8, 0u8, 10u8]; // Size prefix
+    data.extend_from_slice(b"BX"); // Invalid magic (should be "BZ")
+    data.extend_from_slice(&[0u8; 10]);
+    let record = Record::new(data);
+    assert!(!record.compressed()); // Should not be detected as compressed
+}
+
+#[test]
+fn test_decompress_truncated_bzip_stream() {
+    // Valid BZ marker but truncated bzip stream
+    let mut data = vec![0u8, 0u8, 0u8, 100u8]; // Size prefix
+    data.extend_from_slice(b"BZh91AY&SY"); // Valid bzip2 header start
+                                           // No actual compressed data follows
+    let record = Record::new(data);
+    assert!(record.compressed()); // Should be detected as compressed
+
+    let result = record.decompress();
+    // Should fail gracefully, not panic
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_decompress_corrupted_bzip_data() {
+    // Valid BZ marker but corrupted data
+    let mut data = vec![0u8, 0u8, 0u8, 50u8]; // Size prefix
+    data.extend_from_slice(b"BZh9"); // Valid header start
+    data.extend_from_slice(&[0xFFu8; 46]); // Garbage data
+    let record = Record::new(data);
+
+    let result = record.decompress();
+    // Should fail gracefully, not panic
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_record_messages_compressed_data() {
+    // Try to decode messages from compressed data
+    let mut data = vec![0u8, 0u8, 0u8, 10u8]; // Size prefix
+    data.extend_from_slice(b"BZ"); // BZ marker makes it "compressed"
+    data.extend_from_slice(&[0u8; 10]);
+    let record = Record::new(data);
+    assert!(record.compressed());
+
+    let result = record.messages();
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        Error::CompressedDataError => {}
+        other => panic!("Expected CompressedDataError, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_record_short_data_not_compressed() {
+    // Data too short to check for BZ marker
+    let data = vec![0u8; 5];
+    let record = Record::new(data);
+    assert!(!record.compressed());
+}
+
+#[test]
+fn test_record_exactly_six_bytes_no_bz() {
+    // Exactly 6 bytes but no BZ marker
+    let data = vec![0u8, 1u8, 2u8, 3u8, b'X', b'Y'];
+    let record = Record::new(data);
+    assert!(!record.compressed());
+}
+
+#[test]
+fn test_record_exactly_six_bytes_with_bz() {
+    // Exactly 6 bytes with BZ marker at correct position
+    let data = vec![0u8, 0u8, 0u8, 0u8, b'B', b'Z'];
+    let record = Record::new(data);
+    assert!(record.compressed());
+}
+
+#[test]
+fn test_split_multiple_records_second_truncated() {
+    // First record valid, second record truncated
+    let mut data = vec![];
+    // First record: size=10, data
+    data.extend_from_slice(&[0u8, 0u8, 0u8, 10u8]);
+    data.extend_from_slice(&[1u8; 10]);
+    // Second record: size claims 100 but data is truncated
+    data.extend_from_slice(&[0u8, 0u8, 0u8, 100u8]);
+    data.extend_from_slice(&[2u8; 5]); // Only 5 bytes instead of 100
+
+    let result = split_compressed_records(&data);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_split_multiple_valid_records() {
+    // Multiple valid records
+    let mut data = vec![];
+    // First record: size=8, data
+    data.extend_from_slice(&[0u8, 0u8, 0u8, 8u8]);
+    data.extend_from_slice(&[1u8; 8]);
+    // Second record: size=4, data
+    data.extend_from_slice(&[0u8, 0u8, 0u8, 4u8]);
+    data.extend_from_slice(&[2u8; 4]);
+
+    let result = split_compressed_records(&data);
+    assert!(result.is_ok());
+    let records = result.unwrap();
+    assert_eq!(records.len(), 2);
+}

--- a/nexrad-data/tests/volume_records.rs
+++ b/nexrad-data/tests/volume_records.rs
@@ -5,7 +5,7 @@ const TEST_NEXRAD_FILE: &[u8] = include_bytes!("../../downloads/KDMX20220305_232
 #[test]
 fn test_volume_record_splitting() {
     let volume = volume::File::new(TEST_NEXRAD_FILE.to_vec());
-    let records = volume.records().to_vec();
+    let records = volume.records().expect("records").to_vec();
 
     let expected_sizes = vec![
         2335, 233467, 165644, 208109, 261787, 201050, 178271, 88007, 54902, 91951, 112300, 68236,
@@ -50,7 +50,7 @@ fn test_volume_header_decoding() {
 #[test]
 fn test_record_construction_and_data_access() {
     let volume = volume::File::new(TEST_NEXRAD_FILE.to_vec());
-    let records = volume.records();
+    let records = volume.records().expect("records");
 
     let first_record = &records[0];
     let first_record_data = first_record.data().to_vec();
@@ -69,7 +69,7 @@ fn test_record_construction_and_data_access() {
 #[test]
 fn test_record_compression_detection() {
     let volume = volume::File::new(TEST_NEXRAD_FILE.to_vec());
-    let records = volume.records();
+    let records = volume.records().expect("records");
 
     let first_record = &records[0];
     assert!(first_record.compressed());
@@ -95,7 +95,7 @@ fn test_record_compression_detection() {
 #[test]
 fn test_record_decompression() {
     let volume = volume::File::new(TEST_NEXRAD_FILE.to_vec());
-    let records = volume.records();
+    let records = volume.records().expect("records");
 
     let first_record = &records[0];
     assert!(
@@ -127,7 +127,7 @@ fn test_record_decompression() {
 #[test]
 fn test_record_message_decoding() {
     let volume = volume::File::new(TEST_NEXRAD_FILE.to_vec());
-    let records = volume.records();
+    let records = volume.records().expect("records");
 
     let first_record = &records[0];
     let decompressed = first_record
@@ -156,7 +156,7 @@ fn test_record_message_decoding() {
 #[test]
 fn test_full_volume_record_decoding() {
     let volume = volume::File::new(TEST_NEXRAD_FILE.to_vec());
-    let records = volume.records();
+    let records = volume.records().expect("records");
 
     let mut total_messages = 0;
     let mut digital_radar_messages = 0;

--- a/nexrad-decode/benches/decode_messages.rs
+++ b/nexrad-decode/benches/decode_messages.rs
@@ -8,7 +8,7 @@ const TEST_NEXRAD_FILE: &[u8] = include_bytes!("../../downloads/KDMX20220305_232
 
 fn benchmark_decode_messages(c: &mut Criterion) {
     let volume = volume::File::new(TEST_NEXRAD_FILE.to_vec());
-    let mut records = volume.records().into_iter().take(2);
+    let mut records = volume.records().expect("records").into_iter().take(2);
 
     let mut first_record = records.next().expect("first record exists");
     first_record = first_record

--- a/nexrad-decode/examples/elevation_angles.rs
+++ b/nexrad-decode/examples/elevation_angles.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut max_azimuth_num = 0;
 
     // Process all records in the file
-    for mut record in volume_file.records() {
+    for mut record in volume_file.records().expect("records") {
         debug!("Processing record...");
         if record.compressed() {
             debug!("Decompressing LDM record...");

--- a/nexrad-decode/fuzz/.gitignore
+++ b/nexrad-decode/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target/
+corpus/
+artifacts/
+coverage/

--- a/nexrad-decode/fuzz/Cargo.toml
+++ b/nexrad-decode/fuzz/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "nexrad-decode-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[workspace]
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+nexrad-decode = { path = ".." }
+
+[[bin]]
+name = "decode_messages"
+path = "fuzz_targets/decode_messages.rs"
+test = false
+doc = false
+bench = false

--- a/nexrad-decode/fuzz/fuzz_targets/decode_messages.rs
+++ b/nexrad-decode/fuzz/fuzz_targets/decode_messages.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use nexrad_decode::messages::decode_messages;
+
+fuzz_target!(|data: &[u8]| {
+    // Fuzz the message decoding entry point
+    // This should never panic - only return Ok or Err
+    let _ = decode_messages(data);
+});

--- a/nexrad-decode/src/messages/clutter_filter_map/op_code.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/op_code.rs
@@ -7,4 +7,6 @@ pub enum OpCode {
     BypassMapInControl,
     /// The clutter filter is being forced for the range segment.
     ForceFilter,
+    /// Unknown opcode value for forward compatibility.
+    Unknown(u16),
 }

--- a/nexrad-decode/src/messages/clutter_filter_map/range_zone.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/range_zone.rs
@@ -39,7 +39,7 @@ impl<'a> RangeZone<'a> {
             0 => OpCode::BypassFilter,
             1 => OpCode::BypassMapInControl,
             2 => OpCode::ForceFilter,
-            _ => panic!("Invalid OpCode: {}", self.inner.op_code.get()),
+            other => OpCode::Unknown(other),
         }
     }
 

--- a/nexrad-decode/src/messages/digital_radar_data/control_flags.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/control_flags.rs
@@ -5,4 +5,6 @@ pub enum ControlFlags {
     RecombinedAzimuthalRadials,
     RecombinedRangeGates,
     RecombinedRadialsAndRangeGatesToLegacyResolution,
+    /// Unknown control flag value for forward compatibility.
+    Unknown(u8),
 }

--- a/nexrad-decode/src/messages/digital_radar_data/generic_data_block_header.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/generic_data_block_header.rs
@@ -100,7 +100,7 @@ impl<'a> GenericDataBlockHeader<'a> {
             1 => ControlFlags::RecombinedAzimuthalRadials,
             2 => ControlFlags::RecombinedRangeGates,
             3 => ControlFlags::RecombinedRadialsAndRangeGatesToLegacyResolution,
-            _ => panic!("Invalid control flag value: {}", self.inner.control_flags),
+            other => ControlFlags::Unknown(other),
         }
     }
 

--- a/nexrad-decode/src/messages/digital_radar_data/volume_coverage_pattern.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/volume_coverage_pattern.rs
@@ -7,4 +7,6 @@ pub enum VolumeCoveragePattern {
     VCP112,
     VCP212,
     VCP215,
+    /// Unknown VCP number for forward compatibility with new scan strategies.
+    Unknown(u16),
 }

--- a/nexrad-decode/src/messages/digital_radar_data/volume_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/volume_data_block.rs
@@ -254,10 +254,7 @@ impl<'a> VolumeDataBlock<'a> {
             112 => VolumeCoveragePattern::VCP112,
             212 => VolumeCoveragePattern::VCP212,
             215 => VolumeCoveragePattern::VCP215,
-            _ => panic!(
-                "Invalid volume coverage pattern number: {}",
-                volume_coverage_pattern
-            ),
+            other => VolumeCoveragePattern::Unknown(other),
         }
     }
 

--- a/nexrad-decode/src/messages/message.rs
+++ b/nexrad-decode/src/messages/message.rs
@@ -2,7 +2,7 @@ use crate::messages::{
     digital_radar_data, rda_status_data, volume_coverage_pattern, MessageContents, MessageHeader,
     MessageType,
 };
-use crate::result::Result;
+use crate::result::{Error, Result};
 use crate::slice_reader::SliceReader;
 
 /// Expected segment contents size for fixed-length segments.
@@ -32,11 +32,10 @@ impl<'a> Message<'a> {
             if length_delta > 0 {
                 reader.advance(length_delta as usize);
             } else if length_delta < 0 {
-                panic!(
-                    "invalid message length for type {:?}, cannot rewind {} bytes",
-                    header.message_type(),
-                    length_delta
-                );
+                return Err(Error::InvalidMessageLength {
+                    message_type: format!("{:?}", header.message_type()),
+                    delta: length_delta,
+                });
             }
         }
 

--- a/nexrad-decode/src/messages/mod.rs
+++ b/nexrad-decode/src/messages/mod.rs
@@ -26,7 +26,7 @@ pub fn decode_messages<'a>(input: &'a [u8]) -> Result<Vec<Message<'a>>> {
         messages.push(message);
     }
 
-    let bytes_remaining = input.len() - reader.position();
+    let bytes_remaining = input.len().saturating_sub(reader.position());
     if bytes_remaining > 0 {
         warn!(
             "Bytes remaining after decoding all messages: {}",

--- a/nexrad-decode/src/messages/raw/message_header.rs
+++ b/nexrad-decode/src/messages/raw/message_header.rs
@@ -92,7 +92,7 @@ impl MessageHeader {
             8 => RedundantChannel::ORDASingleChannel,
             9 => RedundantChannel::ORDARedundantChannel1,
             10 => RedundantChannel::ORDARedundantChannel2,
-            _ => panic!("Invalid RDA redundant channel: {}", self.redundant_channel),
+            other => RedundantChannel::Unknown(other),
         }
     }
 

--- a/nexrad-decode/src/messages/raw/redundant_channel.rs
+++ b/nexrad-decode/src/messages/raw/redundant_channel.rs
@@ -7,4 +7,6 @@ pub enum RedundantChannel {
     ORDASingleChannel,
     ORDARedundantChannel1,
     ORDARedundantChannel2,
+    /// Unknown redundant channel value for forward compatibility.
+    Unknown(u8),
 }

--- a/nexrad-decode/src/messages/rda_status_data/auxiliary_power_generator_state.rs
+++ b/nexrad-decode/src/messages/rda_status_data/auxiliary_power_generator_state.rs
@@ -6,4 +6,6 @@ pub enum AuxiliaryPowerGeneratorState {
     GeneratorOn,
     TransferSwitchSetToManual,
     CommandedSwitchover,
+    /// Unknown auxiliary power generator state value for forward compatibility.
+    Unknown(u16),
 }

--- a/nexrad-decode/src/messages/rda_status_data/control_authorization.rs
+++ b/nexrad-decode/src/messages/rda_status_data/control_authorization.rs
@@ -4,4 +4,6 @@ pub enum ControlAuthorization {
     NoAction,
     LocalControlRequested,
     RemoteControlRequested,
+    /// Unknown control authorization value for forward compatibility.
+    Unknown(u16),
 }

--- a/nexrad-decode/src/messages/rda_status_data/control_status.rs
+++ b/nexrad-decode/src/messages/rda_status_data/control_status.rs
@@ -4,4 +4,6 @@ pub enum ControlStatus {
     LocalControlOnly,
     RemoteControlOnly,
     EitherLocalOrRemoteControl,
+    /// Unknown control status value for forward compatibility.
+    Unknown(u16),
 }

--- a/nexrad-decode/src/messages/rda_status_data/message.rs
+++ b/nexrad-decode/src/messages/rda_status_data/message.rs
@@ -303,7 +303,7 @@ impl<'a> Message<'a> {
             8 => RDAStatus::Restart,
             16 => RDAStatus::Operate,
             32 => RDAStatus::Spare,
-            _ => panic!("Invalid RDA status: {}", self.inner.rda_status.get()),
+            other => RDAStatus::Unknown(other),
         }
     }
 
@@ -315,10 +315,7 @@ impl<'a> Message<'a> {
             8 => OperabilityStatus::MaintenanceActionMandatory,
             16 => OperabilityStatus::CommandedShutDown,
             32 => OperabilityStatus::Inoperable,
-            _ => panic!(
-                "Invalid RDA operability status: {}",
-                self.inner.operability_status.get()
-            ),
+            other => OperabilityStatus::Unknown(other),
         }
     }
 
@@ -328,10 +325,7 @@ impl<'a> Message<'a> {
             2 => ControlStatus::LocalControlOnly,
             4 => ControlStatus::RemoteControlOnly,
             8 => ControlStatus::EitherLocalOrRemoteControl,
-            _ => panic!(
-                "Invalid RDA control status: {}",
-                self.inner.control_status.get()
-            ),
+            other => ControlStatus::Unknown(other),
         }
     }
 
@@ -343,10 +337,7 @@ impl<'a> Message<'a> {
             4 => AuxiliaryPowerGeneratorState::GeneratorOn,
             8 => AuxiliaryPowerGeneratorState::TransferSwitchSetToManual,
             16 => AuxiliaryPowerGeneratorState::CommandedSwitchover,
-            _ => panic!(
-                "Invalid RDA auxiliary power generator state: {}",
-                self.inner.auxiliary_power_generator_state.get()
-            ),
+            other => AuxiliaryPowerGeneratorState::Unknown(other),
         }
     }
 
@@ -380,10 +371,7 @@ impl<'a> Message<'a> {
             0 => ControlAuthorization::NoAction,
             1 => ControlAuthorization::LocalControlRequested,
             2 => ControlAuthorization::RemoteControlRequested,
-            _ => panic!(
-                "Invalid RDA control authorization: {}",
-                self.inner.rda_control_authorization.get()
-            ),
+            other => ControlAuthorization::Unknown(other),
         }
     }
 
@@ -397,10 +385,7 @@ impl<'a> Message<'a> {
         match self.inner.operational_mode.get() {
             4 => OperationalMode::Operational,
             8 => OperationalMode::Maintenance,
-            _ => panic!(
-                "Invalid RDA operational mode: {}",
-                self.inner.operational_mode.get()
-            ),
+            other => OperationalMode::Unknown(other),
         }
     }
 
@@ -409,10 +394,7 @@ impl<'a> Message<'a> {
         match self.inner.super_resolution_status.get() {
             2 => SuperResolutionStatus::Enabled,
             4 => SuperResolutionStatus::Disabled,
-            _ => panic!(
-                "Invalid RDA super resolution status: {}",
-                self.inner.super_resolution_status.get()
-            ),
+            other => SuperResolutionStatus::Unknown(other),
         }
     }
 
@@ -466,10 +448,7 @@ impl<'a> Message<'a> {
             0 => SpotBlankingStatus::NotInstalled,
             1 => SpotBlankingStatus::Enabled,
             4 => SpotBlankingStatus::Disabled,
-            _ => panic!(
-                "Invalid RDA spot blanking status: {}",
-                self.inner.spot_blanking_status.get()
-            ),
+            other => SpotBlankingStatus::Other(other as u8),
         }
     }
 
@@ -496,10 +475,7 @@ impl<'a> Message<'a> {
             1 => TransitionPowerSourceStatus::Off,
             3 => TransitionPowerSourceStatus::OK,
             4 => TransitionPowerSourceStatus::Unknown,
-            _ => panic!(
-                "Invalid RDA TPS status: {}",
-                self.inner.transition_power_source_status.get()
-            ),
+            other => TransitionPowerSourceStatus::Other(other),
         }
     }
 
@@ -509,10 +485,7 @@ impl<'a> Message<'a> {
             0 => RMSControlStatus::NonRMS,
             2 => RMSControlStatus::RMSInControl,
             4 => RMSControlStatus::RDAInControl,
-            _ => panic!(
-                "Invalid RDA RMS control status: {}",
-                self.inner.rms_control_status.get()
-            ),
+            other => RMSControlStatus::Unknown(other),
         }
     }
 
@@ -522,10 +495,7 @@ impl<'a> Message<'a> {
             0 => PerformanceCheckStatus::NoCommandPending,
             1 => PerformanceCheckStatus::ForcePerformanceCheckPending,
             2 => PerformanceCheckStatus::InProgress,
-            _ => panic!(
-                "Invalid RDA performance check status: {}",
-                self.inner.performance_check_status.get()
-            ),
+            other => PerformanceCheckStatus::Unknown(other),
         }
     }
 

--- a/nexrad-decode/src/messages/rda_status_data/operability_status.rs
+++ b/nexrad-decode/src/messages/rda_status_data/operability_status.rs
@@ -6,4 +6,6 @@ pub enum OperabilityStatus {
     MaintenanceActionMandatory,
     CommandedShutDown,
     Inoperable,
+    /// Unknown operability status value for forward compatibility.
+    Unknown(u16),
 }

--- a/nexrad-decode/src/messages/rda_status_data/operational_mode.rs
+++ b/nexrad-decode/src/messages/rda_status_data/operational_mode.rs
@@ -3,4 +3,6 @@
 pub enum OperationalMode {
     Operational,
     Maintenance,
+    /// Unknown operational mode value for forward compatibility.
+    Unknown(u16),
 }

--- a/nexrad-decode/src/messages/rda_status_data/performance_check_status.rs
+++ b/nexrad-decode/src/messages/rda_status_data/performance_check_status.rs
@@ -4,4 +4,6 @@ pub enum PerformanceCheckStatus {
     NoCommandPending,
     ForcePerformanceCheckPending,
     InProgress,
+    /// Unknown performance check status value for forward compatibility.
+    Unknown(u16),
 }

--- a/nexrad-decode/src/messages/rda_status_data/rda_status.rs
+++ b/nexrad-decode/src/messages/rda_status_data/rda_status.rs
@@ -6,4 +6,6 @@ pub enum RDAStatus {
     Restart,
     Operate,
     Spare,
+    /// Unknown status value for forward compatibility.
+    Unknown(u16),
 }

--- a/nexrad-decode/src/messages/rda_status_data/rms_control_status.rs
+++ b/nexrad-decode/src/messages/rda_status_data/rms_control_status.rs
@@ -4,4 +4,6 @@ pub enum RMSControlStatus {
     NonRMS,
     RMSInControl,
     RDAInControl,
+    /// Unknown RMS control status value for forward compatibility.
+    Unknown(u16),
 }

--- a/nexrad-decode/src/messages/rda_status_data/spot_blanking_status.rs
+++ b/nexrad-decode/src/messages/rda_status_data/spot_blanking_status.rs
@@ -4,4 +4,6 @@ pub enum SpotBlankingStatus {
     NotInstalled,
     Enabled,
     Disabled,
+    /// Unknown spot blanking status value for forward compatibility.
+    Other(u8),
 }

--- a/nexrad-decode/src/messages/rda_status_data/super_resolution_status.rs
+++ b/nexrad-decode/src/messages/rda_status_data/super_resolution_status.rs
@@ -3,4 +3,6 @@
 pub enum SuperResolutionStatus {
     Enabled,
     Disabled,
+    /// Unknown super resolution status value for forward compatibility.
+    Unknown(u16),
 }

--- a/nexrad-decode/src/messages/rda_status_data/transition_power_source_status.rs
+++ b/nexrad-decode/src/messages/rda_status_data/transition_power_source_status.rs
@@ -5,4 +5,6 @@ pub enum TransitionPowerSourceStatus {
     Off,
     OK,
     Unknown,
+    /// Unrecognized TPS status value for forward compatibility.
+    Other(u16),
 }

--- a/nexrad-decode/src/result.rs
+++ b/nexrad-decode/src/result.rs
@@ -16,4 +16,10 @@ pub enum Error {
     MessageMissingDateError,
     #[error("unexpected end of file to input data")]
     UnexpectedEof,
+    #[error("invalid message length for type {message_type}: cannot rewind {delta} bytes")]
+    InvalidMessageLength { message_type: String, delta: i32 },
+    #[error("invalid data block pointer: cannot rewind {bytes} bytes at position {position}")]
+    InvalidDataBlockPointer { bytes: usize, position: usize },
+    #[error("unknown data block type: {block_type}")]
+    UnknownDataBlockType { block_type: String },
 }

--- a/nexrad-decode/src/slice_reader.rs
+++ b/nexrad-decode/src/slice_reader.rs
@@ -39,8 +39,13 @@ impl<'a> SliceReader<'a> {
     }
 
     /// Returns the remaining unread bytes.
+    /// Returns an empty slice if position is at or past the end.
     pub fn remaining(&self) -> &'a [u8] {
-        &self.data[self.pos..]
+        if self.pos >= self.data.len() {
+            &[]
+        } else {
+            &self.data[self.pos..]
+        }
     }
 
     /// Advances the position by `n` bytes.

--- a/nexrad-decode/tests/malformed_input.rs
+++ b/nexrad-decode/tests/malformed_input.rs
@@ -1,0 +1,147 @@
+//! Negative tests for malformed input handling.
+//!
+//! These tests verify that the decode functions gracefully handle invalid,
+//! truncated, and corrupted input data without panicking.
+
+use nexrad_decode::messages::decode_messages;
+
+#[test]
+fn test_empty_input() {
+    let result = decode_messages(&[]);
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_empty());
+}
+
+#[test]
+fn test_single_byte_input() {
+    let result = decode_messages(&[0]);
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_empty());
+}
+
+#[test]
+fn test_truncated_header() {
+    // Message header is 28 bytes, test with less
+    let truncated = vec![0u8; 15];
+    let result = decode_messages(&truncated);
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_empty());
+}
+
+#[test]
+fn test_partial_header() {
+    // Just under the header size
+    let partial = vec![0u8; 27];
+    let result = decode_messages(&partial);
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_empty());
+}
+
+#[test]
+fn test_header_only_no_content() {
+    // Exactly 28 bytes - a header with no content
+    let header_only = vec![0u8; 28];
+    let result = decode_messages(&header_only);
+    // Should either return empty or a message with no content, but not panic
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_random_garbage_data() {
+    // Random-looking data that doesn't conform to any format
+    let garbage: Vec<u8> = (0..1000).map(|i| (i * 17 % 256) as u8).collect();
+    let result = decode_messages(&garbage);
+    // Should not panic regardless of input
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_all_zeros() {
+    let zeros = vec![0u8; 1000];
+    let result = decode_messages(&zeros);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_all_ones() {
+    let ones = vec![0xFFu8; 1000];
+    let result = decode_messages(&ones);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_repeating_pattern() {
+    let pattern: Vec<u8> = (0..1000).map(|i| (i % 16) as u8).collect();
+    let result = decode_messages(&pattern);
+    assert!(result.is_ok());
+}
+
+/// Test that truncated real data doesn't cause panics
+#[test]
+fn test_truncated_real_data() {
+    const TEST_DATA: &[u8] = include_bytes!("data/messages/digital_radar_data_full.bin");
+
+    // Truncate at various points
+    for truncate_at in [1, 10, 50, 100, 500, TEST_DATA.len() / 2] {
+        if truncate_at < TEST_DATA.len() {
+            let truncated = &TEST_DATA[..truncate_at];
+            let result = decode_messages(truncated);
+            // Should not panic, may return error or partial results
+            let _ = result;
+        }
+    }
+}
+
+/// Test with corrupted header fields
+#[test]
+fn test_corrupted_message_type() {
+    // Create a minimal valid-looking header with invalid message type
+    let mut header = vec![0u8; 2432]; // Standard segment size
+                                      // Set message type to an invalid value
+    header[17] = 255;
+    let result = decode_messages(&header);
+    assert!(result.is_ok());
+}
+
+/// Test invalid redundant channel values
+#[test]
+fn test_invalid_redundant_channel() {
+    // This exercises the Unknown variant for redundant channel
+    let mut header = vec![0u8; 2432];
+    // Set redundant channel to an invalid value
+    header[18] = 99;
+    let result = decode_messages(&header);
+    assert!(result.is_ok());
+}
+
+/// Test that the decoder handles minimal sized inputs at boundaries
+#[test]
+fn test_boundary_sizes() {
+    // Test sizes around the header boundary (28 bytes)
+    for size in 26..32 {
+        let data = vec![0u8; size];
+        let result = decode_messages(&data);
+        // Should not panic
+        let _ = result;
+    }
+
+    // Test sizes around the fixed segment size (2432 bytes)
+    for size in 2430..2440 {
+        let data = vec![0u8; size];
+        let result = decode_messages(&data);
+        // Should not panic
+        let _ = result;
+    }
+}
+
+/// Test with oversized message length field
+#[test]
+fn test_oversized_message_length() {
+    let mut data = vec![0u8; 100];
+    // Set message size field to a very large value (bytes 14-15)
+    data[14] = 0xFF;
+    data[15] = 0xFF;
+    let result = decode_messages(&data);
+    // Should not panic even with impossible message size
+    let _ = result;
+}

--- a/nexrad-decode/tests/volume_decode.rs
+++ b/nexrad-decode/tests/volume_decode.rs
@@ -27,7 +27,7 @@ fn test_decode_kdmx_volume_structure() {
     let mut radar_data_count = 0;
     let mut other_count = 0;
 
-    let records: Vec<_> = volume.records().into_iter().collect();
+    let records: Vec<_> = volume.records().expect("records").into_iter().collect();
     assert!(!records.is_empty(), "expected at least one record");
 
     for mut record in records {
@@ -84,7 +84,7 @@ fn test_decode_kcrp_volume_structure() {
     let mut radar_data_count = 0;
     let mut other_count = 0;
 
-    let records: Vec<_> = volume.records().into_iter().collect();
+    let records: Vec<_> = volume.records().expect("records").into_iter().collect();
     assert!(!records.is_empty(), "expected at least one record");
 
     for mut record in records {
@@ -128,7 +128,12 @@ fn test_decode_kdmx_volume_message_ordering() {
     let volume = volume::File::new(KDMX_FILE.to_vec());
 
     // The first record typically contains metadata messages
-    let mut first_record = volume.records().into_iter().next().expect("has records");
+    let mut first_record = volume
+        .records()
+        .expect("records")
+        .into_iter()
+        .next()
+        .expect("has records");
     if first_record.compressed() {
         first_record = first_record.decompress().expect("decompresses");
     }
@@ -155,7 +160,7 @@ fn test_decode_kdmx_volume_radar_data_properties() {
     let mut found_volume_start = false;
     let mut found_volume_end = false;
 
-    for mut record in volume.records() {
+    for mut record in volume.records().expect("records") {
         if record.compressed() {
             record = record.decompress().expect("decompresses");
         }

--- a/nexrad-inspector/src/app.rs
+++ b/nexrad-inspector/src/app.rs
@@ -252,7 +252,7 @@ impl App {
             .ok_or("Failed to parse volume header")?;
 
         let records: Vec<RecordInfo> = volume_file
-            .records()
+            .records()?
             .into_iter()
             .enumerate()
             .map(|(index, record)| RecordInfo {
@@ -288,7 +288,7 @@ impl App {
 
         let file_data = volume_file.data().to_vec();
         let records: Vec<RecordInfo> = volume_file
-            .records()
+            .records()?
             .into_iter()
             .enumerate()
             .map(|(index, record)| RecordInfo {
@@ -553,7 +553,7 @@ impl App {
     pub fn get_decompressed_record(&mut self, index: usize) -> AppResult<&[u8]> {
         if !self.decompressed_cache.contains_key(&index) {
             let volume_file = self.volume_file().ok_or("No file loaded")?;
-            let records = volume_file.records();
+            let records = volume_file.records()?;
             let record = records.get(index).ok_or("Record not found")?;
 
             let decompressed = if record.compressed() {
@@ -897,7 +897,7 @@ impl App {
             } else {
                 // Use original compressed data from file
                 let volume_file = self.volume_file().ok_or("No file loaded")?;
-                let records = volume_file.records();
+                let records = volume_file.records()?;
                 let record = records.get(record_index).ok_or("Record not found")?;
                 let is_compressed = record.compressed();
                 (record.data().to_vec(), !is_compressed)

--- a/nexrad-render/examples/render.rs
+++ b/nexrad-render/examples/render.rs
@@ -15,7 +15,7 @@ fn main() {
 
     let target_elevation_number = 1; // TODO: make this configurable
     let mut radials = Vec::new();
-    for mut record in archive.records() {
+    for mut record in archive.records().expect("records") {
         if record.compressed() {
             record = record.decompress().expect("decompresses successfully");
         }


### PR DESCRIPTION
Harden decoding against malformed input by converting panic points to proper error returns. All public entrypoints now return `Err` instead of panicking on invalid data.

- Convert panic sites to error returns or `Unknown` enum variants
- Fix bounds checking in `SliceReader::remaining()` and `split_compressed_records`
- Add test coverage for truncation, corruption, and boundary conditions
- Add `cargo-fuzz` for `decode_messages`, `split_records`, and `decompress_record`

Closes #71