### PR TITLE
Auto-dismiss status update after 3s

### DIFF
--- a/nexrad-inspector/src/main.rs
+++ b/nexrad-inspector/src/main.rs
@@ -88,6 +88,9 @@ where
             app.tick_spinner();
         }
 
+        // Auto-dismiss status messages
+        app.tick_status_message();
+
         // Check quit flag
         if app.should_quit {
             return Ok(());


### PR DESCRIPTION
When a status message is shown in nexard-inspector, it stays there forever and covers keyboard shortcuts. We should have them dismiss automatically after a few seconds.

Closes #77.