### PR TITLE
Simplify raw types' publicity/exports

### DIFF
--- a/nexrad-decode/src/messages/clutter_filter_map/raw/azimuth_segment_header.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/raw/azimuth_segment_header.rs
@@ -6,5 +6,5 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 #[derive(Debug, Clone, PartialEq, Eq, Hash, FromBytes, Immutable, KnownLayout)]
 pub struct AzimuthSegmentHeader {
     /// The number of range zones defined in this azimuth segment, from 1 to 20.
-    pub(crate) range_zone_count: Integer2,
+    pub range_zone_count: Integer2,
 }

--- a/nexrad-decode/src/messages/clutter_filter_map/raw/header.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/raw/header.rs
@@ -9,12 +9,12 @@ pub struct Header {
     /// The date the clutter filter map was generated represented as a count of days since 1 January
     /// 1970 00:00 GMT. It is also referred-to as a "modified Julian date" where it is the Julian
     /// date - 2440586.5.
-    pub(crate) map_generation_date: Integer2,
+    pub map_generation_date: Integer2,
 
     /// The time the clutter filter map was generated in minutes past midnight, GMT.
-    pub(crate) map_generation_time: Integer2,
+    pub map_generation_time: Integer2,
 
     /// The number of elevation segments defined in this clutter filter map. There may be 1 to 5,
     /// though there are typically 2. They will follow this header in order of increasing elevation.
-    pub(crate) elevation_segment_count: Integer2,
+    pub elevation_segment_count: Integer2,
 }

--- a/nexrad-decode/src/messages/clutter_filter_map/raw/mod.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/raw/mod.rs
@@ -1,8 +1,8 @@
-pub(crate) mod header;
-pub(crate) use header::Header;
+mod header;
+pub use header::Header;
 
-pub(crate) mod azimuth_segment_header;
-pub(crate) use azimuth_segment_header::AzimuthSegmentHeader;
+mod azimuth_segment_header;
+pub use azimuth_segment_header::AzimuthSegmentHeader;
 
-pub(crate) mod range_zone;
-pub(crate) use range_zone::RangeZone;
+mod range_zone;
+pub use range_zone::RangeZone;

--- a/nexrad-decode/src/messages/clutter_filter_map/raw/range_zone.rs
+++ b/nexrad-decode/src/messages/clutter_filter_map/raw/range_zone.rs
@@ -8,9 +8,9 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 #[derive(Clone, PartialEq, Eq, Hash, Debug, FromBytes, Immutable, KnownLayout)]
 pub struct RangeZone {
     /// Operation code for the range zone.
-    pub(crate) op_code: Code2,
+    pub op_code: Code2,
 
     /// Stop range per zone in km. There are 20 possible zones and not all need to be defined. The
     /// last zone must have an end range of 511km.
-    pub(crate) end_range: Integer2,
+    pub end_range: Integer2,
 }

--- a/nexrad-decode/src/messages/digital_radar_data/raw/data_block_id.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/raw/data_block_id.rs
@@ -6,8 +6,8 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 #[derive(Clone, PartialEq, Eq, Hash, Debug, FromBytes, Immutable, KnownLayout)]
 pub struct DataBlockId {
     /// Data block type, e.g. "R".
-    pub(crate) data_block_type: u8,
+    pub data_block_type: u8,
 
     /// Data block name, e.g. "VOL".
-    pub(crate) data_name: [u8; 3],
+    pub data_name: [u8; 3],
 }

--- a/nexrad-decode/src/messages/digital_radar_data/raw/elevation_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/raw/elevation_data_block.rs
@@ -7,12 +7,12 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 #[derive(Clone, PartialEq, Debug, FromBytes, Immutable, KnownLayout)]
 pub struct ElevationDataBlock {
     /// Size of data block in bytes.
-    pub(crate) lrtup: Integer2,
+    pub lrtup: Integer2,
 
     /// Atmospheric attenuation factor in dB/km.
-    pub(crate) atmos: ScaledSInteger2,
+    pub atmos: ScaledSInteger2,
 
     /// Scaling constant used by the signal processor for this elevation to calculate reflectivity
     /// in dB.
-    pub(crate) calibration_constant: Real4,
+    pub calibration_constant: Real4,
 }

--- a/nexrad-decode/src/messages/digital_radar_data/raw/generic_data_block_header.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/raw/generic_data_block_header.rs
@@ -9,23 +9,23 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 #[derive(Clone, PartialEq, Debug, FromBytes, Immutable, KnownLayout)]
 pub struct GenericDataBlockHeader {
     /// Reserved.
-    pub(crate) reserved: Integer4,
+    pub reserved: Integer4,
 
     /// Number of data moment gates for current radial, from 0 to 1840.
-    pub(crate) number_of_data_moment_gates: Integer2,
+    pub number_of_data_moment_gates: Integer2,
 
     /// Range to center of first range gate in 0.000-scaled kilometers.
-    pub(crate) data_moment_range: ScaledInteger2,
+    pub data_moment_range: ScaledInteger2,
 
     /// Size of data moment sample interval in 0.000-scaled kilometers from 0.25 to 4.0.
-    pub(crate) data_moment_range_sample_interval: ScaledInteger2,
+    pub data_moment_range_sample_interval: ScaledInteger2,
 
     /// Threshold parameter specifying the minimum difference in echo power between two resolution
     /// gates in dB for them to not be labeled as "overlayed".
-    pub(crate) tover: ScaledInteger2,
+    pub tover: ScaledInteger2,
 
     /// Signal-to-noise ratio threshold for valid data from -12 to 20 dB.
-    pub(crate) snr_threshold: ScaledInteger2,
+    pub snr_threshold: ScaledInteger2,
 
     /// Flags indicating special control features.
     ///
@@ -34,14 +34,14 @@ pub struct GenericDataBlockHeader {
     ///   1 = Recombined azimuthal radials
     ///   2 = Recombined range gates
     ///   3 = Recombined radials and range gates to legacy resolution
-    pub(crate) control_flags: Code1,
+    pub control_flags: Code1,
 
     /// Number of bits (8 or 16) used for storing data for each data moment gate.
-    pub(crate) data_word_size: Integer1,
+    pub data_word_size: Integer1,
 
     /// Scale factor for converting data moments to floating-point representation.
-    pub(crate) scale: Real4,
+    pub scale: Real4,
 
     /// Offset value for converting data moments to floating-point representation.
-    pub(crate) offset: Real4,
+    pub offset: Real4,
 }

--- a/nexrad-decode/src/messages/digital_radar_data/raw/header.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/raw/header.rs
@@ -10,20 +10,20 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 #[derive(Clone, PartialEq, Debug, FromBytes, Immutable, KnownLayout)]
 pub struct Header {
     /// ICAO radar identifier.
-    pub(crate) radar_identifier: [u8; 4],
+    pub radar_identifier: [u8; 4],
 
     /// Collection time in milliseconds past midnight, GMT.
-    pub(crate) time: Integer4,
+    pub time: Integer4,
 
     /// This message's date represented as a count of days since 1 January 1970 00:00 GMT. It is
     /// also referred-to as a "modified Julian date" where it is the Julian date - 2440586.5.
-    pub(crate) date: Integer2,
+    pub date: Integer2,
 
     /// Radial number within the elevation scan. These range up to 720, in 0.5 degree increments.
-    pub(crate) azimuth_number: Integer2,
+    pub azimuth_number: Integer2,
 
     /// Azimuth angle at which the radial was collected in degrees.
-    pub(crate) azimuth_angle: Real4,
+    pub azimuth_angle: Real4,
 
     /// Indicates if the message is compressed and what type of compression was used. This header is
     /// not compressed.
@@ -33,13 +33,13 @@ pub struct Header {
     ///   1 = Compressed using BZIP2
     ///   2 = Compressed using ZLIB
     ///   3 = Future use
-    pub(crate) compression_indicator: Code1,
+    pub compression_indicator: Code1,
 
     /// Spare to force halfword alignment.
-    pub(crate) spare: u8,
+    pub spare: u8,
 
     /// Uncompressed length of the radial in bytes (including the data header block).
-    pub(crate) radial_length: Integer2,
+    pub radial_length: Integer2,
 
     /// Azimuthal spacing between adjacent radials. Note this is the commanded value, not
     /// necessarily the actual spacing.
@@ -47,7 +47,7 @@ pub struct Header {
     /// Values:
     ///   1 = 0.5 degrees
     ///   2 = 1.0 degrees
-    pub(crate) azimuth_resolution_spacing: Code1,
+    pub azimuth_resolution_spacing: Code1,
 
     /// The radial's status within the larger scan (e.g. first, last).
     ///
@@ -58,16 +58,16 @@ pub struct Header {
     ///   3 = Start of volume scan
     ///   4 = End of volume scan
     ///   5 = Start of new elevation which is the last in the VCP
-    pub(crate) radial_status: Code1,
+    pub radial_status: Code1,
 
     /// The radial's elevation number within the volume scan.
-    pub(crate) elevation_number: Integer1,
+    pub elevation_number: Integer1,
 
     /// The sector number within cut. A value of 0 is only valid for continuous surveillance cuts.
-    pub(crate) cut_sector_number: Integer1,
+    pub cut_sector_number: Integer1,
 
     /// The radial's collection elevation angle.
-    pub(crate) elevation_angle: Real4,
+    pub elevation_angle: Real4,
 
     /// The spot blanking status for the current radial, elevation, and volume scan.
     ///
@@ -76,18 +76,18 @@ pub struct Header {
     ///   1 = Radial
     ///   2 = Elevation
     ///   4 = Volume
-    pub(crate) radial_spot_blanking_status: Code1,
+    pub radial_spot_blanking_status: Code1,
 
     /// The azimuth indexing value (if keyed to constant angles).
     ///
     /// Values:
     ///   0     = No indexing
     ///   1-100 = Indexing angle of 0.01 to 1.00 degrees
-    pub(crate) azimuth_indexing_mode: ScaledInteger1,
+    pub azimuth_indexing_mode: ScaledInteger1,
 
     /// The number of "data moment" blocks following this header block, from 4 to 10. There are
     /// always volume, elevation, and radial information blocks and a reflectivity data moment
     /// block. The following 6 data moment blocks are optional, depending on scanning mode. The next
     /// 10 fields on this header contain pointers to each block, if available in the message.
-    pub(crate) data_block_count: Integer2,
+    pub data_block_count: Integer2,
 }

--- a/nexrad-decode/src/messages/digital_radar_data/raw/mod.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/raw/mod.rs
@@ -1,17 +1,17 @@
-pub(crate) mod data_block_id;
-pub(crate) use data_block_id::DataBlockId;
+mod data_block_id;
+pub use data_block_id::DataBlockId;
 
-pub(crate) mod elevation_data_block;
-pub(crate) use elevation_data_block::ElevationDataBlock;
+mod elevation_data_block;
+pub use elevation_data_block::ElevationDataBlock;
 
-pub(crate) mod generic_data_block_header;
-pub(crate) use generic_data_block_header::GenericDataBlockHeader;
+mod generic_data_block_header;
+pub use generic_data_block_header::GenericDataBlockHeader;
 
-pub(crate) mod header;
-pub(crate) use header::Header;
+mod header;
+pub use header::Header;
 
-pub(crate) mod radial_data_block;
-pub(crate) use radial_data_block::RadialDataBlock;
+mod radial_data_block;
+pub use radial_data_block::RadialDataBlock;
 
-pub(crate) mod volume_data_block;
-pub(crate) use volume_data_block::{VolumeDataBlock, VolumeDataBlockLegacy};
+mod volume_data_block;
+pub use volume_data_block::{VolumeDataBlock, VolumeDataBlockLegacy};

--- a/nexrad-decode/src/messages/digital_radar_data/raw/radial_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/raw/radial_data_block.rs
@@ -7,26 +7,26 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 #[derive(Clone, PartialEq, Debug, FromBytes, Immutable, KnownLayout)]
 pub struct RadialDataBlock {
     /// Size of data block in bytes.
-    pub(crate) lrtup: Integer2,
+    pub lrtup: Integer2,
 
     /// Unambiguous range, interval size, in km.
-    pub(crate) unambiguous_range: ScaledInteger2,
+    pub unambiguous_range: ScaledInteger2,
 
     /// Noise level for the horizontal channel in dBm.
-    pub(crate) horizontal_channel_noise_level: Real4,
+    pub horizontal_channel_noise_level: Real4,
 
     /// Noise level for the vertical channel in dBm.
-    pub(crate) vertical_channel_noise_level: Real4,
+    pub vertical_channel_noise_level: Real4,
 
     /// Nyquist velocity in m/s.
-    pub(crate) nyquist_velocity: ScaledInteger2,
+    pub nyquist_velocity: ScaledInteger2,
 
     /// Radial flags to support RPG processing.
-    pub(crate) radial_flags: Integer2,
+    pub radial_flags: Integer2,
 
     /// Calibration constant for the horizontal channel in dBZ.
-    pub(crate) horizontal_channel_calibration_constant: Real4,
+    pub horizontal_channel_calibration_constant: Real4,
 
     /// Calibration constant for the vertical channel in dBZ.
-    pub(crate) vertical_channel_calibration_constant: Real4,
+    pub vertical_channel_calibration_constant: Real4,
 }

--- a/nexrad-decode/src/messages/digital_radar_data/raw/volume_data_block.rs
+++ b/nexrad-decode/src/messages/digital_radar_data/raw/volume_data_block.rs
@@ -11,51 +11,51 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 #[derive(Clone, PartialEq, Debug, FromBytes, Immutable, KnownLayout)]
 pub struct VolumeDataBlockLegacy {
     /// Size of data block in bytes.
-    pub(crate) lrtup: Integer2,
+    pub lrtup: Integer2,
 
     /// Major version number.
-    pub(crate) major_version_number: Integer1,
+    pub major_version_number: Integer1,
 
     /// Minor version number.
-    pub(crate) minor_version_number: Integer1,
+    pub minor_version_number: Integer1,
 
     /// Latitude of radar in degrees.
-    pub(crate) latitude: Real4,
+    pub latitude: Real4,
 
     /// Longitude of radar in degrees.
-    pub(crate) longitude: Real4,
+    pub longitude: Real4,
 
     /// Height of site base above sea level in meters.
-    pub(crate) site_height: SInteger2,
+    pub site_height: SInteger2,
 
     /// Height of feedhorn above ground in meters.
-    pub(crate) feedhorn_height: Integer2,
+    pub feedhorn_height: Integer2,
 
     /// Reflectivity scaling factor without correction by ground noise scaling factors given in
     /// adaptation data message in dB.
-    pub(crate) calibration_constant: Real4,
+    pub calibration_constant: Real4,
 
     /// Transmitter power for horizontal channel in kW.
-    pub(crate) horizontal_shv_tx_power: Real4,
+    pub horizontal_shv_tx_power: Real4,
 
     /// Transmitter power for vertical channel in kW.
-    pub(crate) vertical_shv_tx_power: Real4,
+    pub vertical_shv_tx_power: Real4,
 
     /// Calibration of system ZDR in dB.
-    pub(crate) system_differential_reflectivity: Real4,
+    pub system_differential_reflectivity: Real4,
 
     /// Initial DP for the system in degrees.
-    pub(crate) initial_system_differential_phase: Real4,
+    pub initial_system_differential_phase: Real4,
 
     /// Identifies the volume coverage pattern in use.
-    pub(crate) volume_coverage_pattern_number: Integer2,
+    pub volume_coverage_pattern_number: Integer2,
 
     /// Processing option flags.
     ///
     /// Options:
     ///   0 = RxR noise
     ///   1 = CBT
-    pub(crate) processing_status: Integer2,
+    pub processing_status: Integer2,
 }
 
 /// A volume data moment block (Build 18.0 and later, 48 bytes).
@@ -63,55 +63,55 @@ pub struct VolumeDataBlockLegacy {
 #[derive(Clone, PartialEq, Debug, FromBytes, Immutable, KnownLayout)]
 pub struct VolumeDataBlock {
     /// Size of data block in bytes.
-    pub(crate) lrtup: Integer2,
+    pub lrtup: Integer2,
 
     /// Major version number.
-    pub(crate) major_version_number: Integer1,
+    pub major_version_number: Integer1,
 
     /// Minor version number.
-    pub(crate) minor_version_number: Integer1,
+    pub minor_version_number: Integer1,
 
     /// Latitude of radar in degrees.
-    pub(crate) latitude: Real4,
+    pub latitude: Real4,
 
     /// Longitude of radar in degrees.
-    pub(crate) longitude: Real4,
+    pub longitude: Real4,
 
     /// Height of site base above sea level in meters.
-    pub(crate) site_height: SInteger2,
+    pub site_height: SInteger2,
 
     /// Height of feedhorn above ground in meters.
-    pub(crate) feedhorn_height: Integer2,
+    pub feedhorn_height: Integer2,
 
     /// Reflectivity scaling factor without correction by ground noise scaling factors given in
     /// adaptation data message in dB.
-    pub(crate) calibration_constant: Real4,
+    pub calibration_constant: Real4,
 
     /// Transmitter power for horizontal channel in kW.
-    pub(crate) horizontal_shv_tx_power: Real4,
+    pub horizontal_shv_tx_power: Real4,
 
     /// Transmitter power for vertical channel in kW.
-    pub(crate) vertical_shv_tx_power: Real4,
+    pub vertical_shv_tx_power: Real4,
 
     /// Calibration of system ZDR in dB.
-    pub(crate) system_differential_reflectivity: Real4,
+    pub system_differential_reflectivity: Real4,
 
     /// Initial DP for the system in degrees.
-    pub(crate) initial_system_differential_phase: Real4,
+    pub initial_system_differential_phase: Real4,
 
     /// Identifies the volume coverage pattern in use.
-    pub(crate) volume_coverage_pattern_number: Integer2,
+    pub volume_coverage_pattern_number: Integer2,
 
     /// Processing option flags.
     ///
     /// Options:
     ///   0 = RxR noise
     ///   1 = CBT
-    pub(crate) processing_status: Integer2,
+    pub processing_status: Integer2,
 
     /// RPG weighted mean ZDR bias estimate in dB.
-    pub(crate) zdr_bias_estimate_weighted_mean: Integer2,
+    pub zdr_bias_estimate_weighted_mean: Integer2,
 
     /// Spare.
-    pub(crate) spare: BinaryData<[u8; 6]>,
+    pub spare: BinaryData<[u8; 6]>,
 }

--- a/nexrad-decode/src/messages/rda_status_data/raw/message.rs
+++ b/nexrad-decode/src/messages/rda_status_data/raw/message.rs
@@ -16,7 +16,7 @@ pub struct Message {
     ///  16 (bit 4) = Operate
     ///  32 (bit 5) = Spare
     ///  64 (bit 6) = Spare
-    pub(crate) rda_status: Code2,
+    pub rda_status: Code2,
 
     /// The RDA system's operability status.
     ///
@@ -26,7 +26,7 @@ pub struct Message {
     ///   8 (bit 3) = Maintenance action mandatory
     ///  16 (bit 4) = Commanded shut down
     ///  32 (bit 5) = Inoperable
-    pub(crate) operability_status: Code2,
+    pub operability_status: Code2,
 
     /// The RDA system's control status.
     ///
@@ -34,7 +34,7 @@ pub struct Message {
     ///   2 (bit 1) = Local control only
     ///   4 (bit 2) = Remote (RPG) control only
     ///   8 (bit 3) = Either local or remote control
-    pub(crate) control_status: Code2,
+    pub control_status: Code2,
 
     /// The RDA system's auxiliary power generator state.
     ///
@@ -44,14 +44,14 @@ pub struct Message {
     ///   4 (bit 2) = Generator on
     ///   8 (bit 3) = Transfer switch set to manual
     ///  16 (bit 4) = Commanded switchover
-    pub(crate) auxiliary_power_generator_state: Code2,
+    pub auxiliary_power_generator_state: Code2,
 
     /// The average transmitter power in watts calculated over a range of samples.
-    pub(crate) average_transmitter_power: Integer2,
+    pub average_transmitter_power: Integer2,
 
     /// Difference from adaptation data (delta dBZ0) in dB. Scaling is two decimal places, e.g.
     /// a value of -19800 represents -198.00 dB.
-    pub(crate) horizontal_reflectivity_calibration_correction: ScaledInteger2,
+    pub horizontal_reflectivity_calibration_correction: ScaledInteger2,
 
     /// Which types of data have transmission enabled.
     ///
@@ -60,13 +60,13 @@ pub struct Message {
     ///   2 (bit 2) = Reflectivity
     ///   4 (bit 3) = Velocity
     ///   8 (bit 4) = Spectrum width
-    pub(crate) data_transmission_enabled: Code2,
+    pub data_transmission_enabled: Code2,
 
     /// The radar's volume coverage pattern number.
     ///
     /// The magnitude of the value identifies the pattern, and the sign indicates whether it was
     /// specified locally or remotely. Zero indicates no pattern.
-    pub(crate) volume_coverage_pattern: SInteger2,
+    pub volume_coverage_pattern: SInteger2,
 
     /// The RDA system's mode of control.
     ///
@@ -74,27 +74,27 @@ pub struct Message {
     ///   0 (none)  = No action
     ///   2 (bit 1) = Local control requested
     ///   4 (bit 2) = Remote control requested (local released)
-    pub(crate) rda_control_authorization: Code2,
+    pub rda_control_authorization: Code2,
 
     /// The RDA system's major and minor build numbers.
     ///
     /// If the value divided by 100 is greater than 2 then the build version is the value divided
     /// by 100, otherwise it is divided by 10.
-    pub(crate) rda_build_number: ScaledInteger2,
+    pub rda_build_number: ScaledInteger2,
 
     /// Whether the RDA system is operational.
     ///
     /// Modes:
     ///   4 (bit 2) = Operational
     ///   8 (bit 3) = Maintenance
-    pub(crate) operational_mode: Code2,
+    pub operational_mode: Code2,
 
     /// Whether the RDA system has super resolution enabled.
     ///
     /// Statuses:
     ///   2 (bit 1) = Enabled
     ///   4 (bit 2) = Disabled
-    pub(crate) super_resolution_status: Code2,
+    pub super_resolution_status: Code2,
 
     /// The RDA system's clutter mitigation status.
     ///
@@ -108,7 +108,7 @@ pub struct Message {
     ///   8 (bit 3) = Bypass map elevation 3 applied
     ///  16 (bit 4) = Bypass map elevation 4 applied
     ///  32 (bit 5) = Bypass map elevation 5 applied
-    pub(crate) clutter_mitigation_decision_status: Code2,
+    pub clutter_mitigation_decision_status: Code2,
 
     /// Multiple flags for the RDA system's scan and data status.
     ///
@@ -118,7 +118,7 @@ pub struct Message {
     ///   8 (bit 3) = EBC enablement
     ///  16 (bit 4) = RDA log data enablement
     ///  32 (bit 5) = Time series data recording enablement
-    pub(crate) rda_scan_and_data_flags: Code2,
+    pub rda_scan_and_data_flags: Code2,
 
     /// The RDA system's active alarm types.
     ///
@@ -131,7 +131,7 @@ pub struct Message {
     ///  16 (bit 5) = RDA control
     ///  32 (bit 6) = Communication
     ///  64 (bit 7) = Signal processor
-    pub(crate) rda_alarm_summary: Code2,
+    pub rda_alarm_summary: Code2,
 
     /// Acknowledgement of command receipt by RDA system.
     ///
@@ -141,14 +141,14 @@ pub struct Message {
     ///   2 (bit 1)   = Clutter bypass map received
     ///   3 (bit 0&1) = Clutter censor zones received
     ///   4 (bit 2)   = Redundant channel control command accepted
-    pub(crate) command_acknowledgement: Code2,
+    pub command_acknowledgement: Code2,
 
     /// Indicates whether this is the RDA system's controlling channel.
     ///
     /// Values:
     ///   0 (none)  = Controlling channel
     ///   1 (bit 0) = Non-controlling channel
-    pub(crate) channel_control_status: Code2,
+    pub channel_control_status: Code2,
 
     /// The RDA system's spot blanking status.
     ///
@@ -156,25 +156,25 @@ pub struct Message {
     ///   0 (none)  = Not installed
     ///   1 (bit 1) = Enabled
     ///   4 (bit 2) = Disabled
-    pub(crate) spot_blanking_status: Code2,
+    pub spot_blanking_status: Code2,
 
     /// The bypass map generation date represented as a count of days since 1 January 1970 00:00 GMT.
     /// It is also referred-to as a "modified Julian date" where it is the Julian date - 2440586.5.
-    pub(crate) bypass_map_generation_date: Integer2,
+    pub bypass_map_generation_date: Integer2,
 
     /// The bypass map generation time in minutes past midnight, GMT.
-    pub(crate) bypass_map_generation_time: Integer2,
+    pub bypass_map_generation_time: Integer2,
 
     /// The clutter filter map generation date represented as a count of days since 1 January 1970
     /// 00:00 GMT. It is also referred-to as a "modified Julian date" where it is the
     /// Julian date - 2440586.5.
-    pub(crate) clutter_filter_map_generation_date: Integer2,
+    pub clutter_filter_map_generation_date: Integer2,
 
     /// The clutter filter map generation time in minutes past midnight, GMT.
-    pub(crate) clutter_filter_map_generation_time: Integer2,
+    pub clutter_filter_map_generation_time: Integer2,
 
     /// The RDA system's vertical reflectivity calibration correction in dB.
-    pub(crate) vertical_reflectivity_calibration_correction: ScaledInteger2,
+    pub vertical_reflectivity_calibration_correction: ScaledInteger2,
 
     /// The RDA system's TPS.
     ///
@@ -183,7 +183,7 @@ pub struct Message {
     ///   1 (bit 0)   = Off
     ///   3 (bit 0&1) = OK
     ///   4 (bit 2)   = Unknown
-    pub(crate) transition_power_source_status: Integer2,
+    pub transition_power_source_status: Integer2,
 
     /// The RDA system's RMS control status.
     ///
@@ -191,7 +191,7 @@ pub struct Message {
     ///   0 (none)  = Non-RMS system
     ///   2 (bit 1) = RMS in control
     ///   4 (bit 2) = RDA in control
-    pub(crate) rms_control_status: Code2,
+    pub rms_control_status: Code2,
 
     /// The RDA system's performance check status.
     ///
@@ -199,16 +199,16 @@ pub struct Message {
     ///   0 (none)  = No command pending
     ///   1 (bit 0) = Force performance check pending
     ///   2 (bit 1) = In progress
-    pub(crate) performance_check_status: Code2,
+    pub performance_check_status: Code2,
 
     /// The RDA system's alarm codes stored per-halfword up to 14 possible codes.
-    pub(crate) alarm_codes: [Integer2; 14],
+    pub alarm_codes: [Integer2; 14],
 
     /// Flags indicating the various RDA signal processing options.
-    pub(crate) signal_processor_options: Code2,
+    pub signal_processor_options: Code2,
 
-    pub(crate) spares: [Integer2; 18],
+    pub spares: [Integer2; 18],
 
     /// Version of status message.
-    pub(crate) status_version: Integer2,
+    pub status_version: Integer2,
 }

--- a/nexrad-decode/src/messages/rda_status_data/raw/mod.rs
+++ b/nexrad-decode/src/messages/rda_status_data/raw/mod.rs
@@ -1,2 +1,2 @@
-pub(crate) mod message;
-pub(crate) use message::Message;
+mod message;
+pub use message::Message;

--- a/nexrad-decode/src/messages/volume_coverage_pattern/raw/elevation_data_block.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/raw/elevation_data_block.rs
@@ -8,13 +8,13 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 #[derive(Clone, PartialEq, Debug, FromBytes, Immutable, KnownLayout)]
 pub struct ElevationDataBlock {
     /// The elevation angle for this cut
-    pub(crate) elevation_angle: Code2,
+    pub elevation_angle: Code2,
 
     /// The channel configuration for this cut
     /// 0 => Constant Phase
     /// 1 => Random Phase
     /// 2 => SZ2 Phase
-    pub(crate) channel_configuration: Code1,
+    pub channel_configuration: Code1,
 
     /// The waveform type for this cut
     /// 1 => Contiguous Surveillance
@@ -22,50 +22,50 @@ pub struct ElevationDataBlock {
     /// 3 => Contiguous Doppler w/o Ambiguity Resolution
     /// 4 => Batch
     /// 5 => Staggered Pulse Pair
-    pub(crate) waveform_type: Code1,
+    pub waveform_type: Code1,
 
     /// Super resolution control values for this cut
     /// Bit 0: 0.5 degree azimuth
     /// Bit 1: 1/4 km reflectivity
     /// Bit 2: Doppler to 300 km
     /// Bit 3: Dual polarization to 300 km
-    pub(crate) super_resolution_control: Code1,
+    pub super_resolution_control: Code1,
 
     /// The pulse repetition frequency number for surveillance cuts
-    pub(crate) surveillance_prf_number: Integer1,
+    pub surveillance_prf_number: Integer1,
 
     /// The pulse count per radial for surveillance cuts
-    pub(crate) surveillance_prf_pulse_count_radial: Integer2,
+    pub surveillance_prf_pulse_count_radial: Integer2,
 
     /// The azimuth rate of the cut
-    pub(crate) azimuth_rate: Code2,
+    pub azimuth_rate: Code2,
 
     /// Signal to noise ratio (SNR) threshold for reflectivity
-    pub(crate) reflectivity_threshold: ScaledSInteger2,
+    pub reflectivity_threshold: ScaledSInteger2,
 
     /// Signal to noise ratio (SNR) threshold for velocity
-    pub(crate) velocity_threshold: ScaledSInteger2,
+    pub velocity_threshold: ScaledSInteger2,
 
     /// Signal to noise ratio (SNR) threshold for spectrum width
-    pub(crate) spectrum_width_threshold: ScaledSInteger2,
+    pub spectrum_width_threshold: ScaledSInteger2,
 
     /// Signal to noise ratio (SNR) threshold for differential reflectivity
-    pub(crate) differential_reflectivity_threshold: ScaledSInteger2,
+    pub differential_reflectivity_threshold: ScaledSInteger2,
 
     /// Signal to noise ratio (SNR) threshold for differential phase
-    pub(crate) differential_phase_threshold: ScaledSInteger2,
+    pub differential_phase_threshold: ScaledSInteger2,
 
     /// Signal to noise ratio (SNR) threshold for correlation coefficitn
-    pub(crate) correlation_coefficient_threshold: ScaledSInteger2,
+    pub correlation_coefficient_threshold: ScaledSInteger2,
 
     /// Sector 1 Azimuth Clockwise Edge Angle (denotes start angle)
-    pub(crate) sector_1_edge_angle: Code2,
+    pub sector_1_edge_angle: Code2,
 
     /// Sector 1 Doppler PRF Number
-    pub(crate) sector_1_doppler_prf_number: Integer2,
+    pub sector_1_doppler_prf_number: Integer2,
 
     /// Sector 1 Doppler Pulse Count/Radial
-    pub(crate) sector_1_doppler_prf_pulse_count_radial: Integer2,
+    pub sector_1_doppler_prf_pulse_count_radial: Integer2,
 
     /// Supplemental Data
     /// Bit 0:    SAILS Cut
@@ -75,35 +75,35 @@ pub struct ElevationDataBlock {
     /// Bit 8:    Spare
     /// Bit 9:    MPDA Cut
     /// Bit 10:   BASE TILT Cut
-    pub(crate) supplemental_data: Code2,
+    pub supplemental_data: Code2,
 
     /// Sector 2 Azimuth Clockwise Edge Angle (denotes start angle)
-    pub(crate) sector_2_edge_angle: Code2,
+    pub sector_2_edge_angle: Code2,
 
     /// Sector 2 Doppler PRF Number
-    pub(crate) sector_2_doppler_prf_number: Integer2,
+    pub sector_2_doppler_prf_number: Integer2,
 
     /// Sector 2 Doppler Pulse Count/Radial
-    pub(crate) sector_2_doppler_prf_pulse_count_radial: Integer2,
+    pub sector_2_doppler_prf_pulse_count_radial: Integer2,
 
     /// The correction added to the elevation angle for this cut
-    pub(crate) ebc_angle: Code2,
+    pub ebc_angle: Code2,
 
     /// Sector 3 Azimuth Clockwise Edge Angle (denotes start angle)
-    pub(crate) sector_3_edge_angle: Code2,
+    pub sector_3_edge_angle: Code2,
 
     /// Sector 3 Doppler PRF Number
-    pub(crate) sector_3_doppler_prf_number: Integer2,
+    pub sector_3_doppler_prf_number: Integer2,
 
     /// Sector 3 Doppler Pulse Count/Radial
-    pub(crate) sector_3_doppler_prf_pulse_count_radial: Integer2,
+    pub sector_3_doppler_prf_pulse_count_radial: Integer2,
 
     /// Reserved
-    pub(crate) reserved: Integer2,
+    pub reserved: Integer2,
 }
 
 /// Decodes an angle as defined in table III-A of ICD 2620002W
-pub(crate) fn decode_angle(raw: Code2) -> f64 {
+pub fn decode_angle(raw: Code2) -> f64 {
     let mut angle: f64 = 0.0;
     for i in 3..16 {
         if ((raw >> i) & 1) == 1 {
@@ -115,7 +115,7 @@ pub(crate) fn decode_angle(raw: Code2) -> f64 {
 }
 
 /// Decodes an angular velocity as defined in table XI-D of ICD 2620002W
-pub(crate) fn decode_angular_velocity(raw: Code2) -> f64 {
+pub fn decode_angular_velocity(raw: Code2) -> f64 {
     let mut angular_velocity: f64 = 0.0;
 
     for i in 3..15 {

--- a/nexrad-decode/src/messages/volume_coverage_pattern/raw/header.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/raw/header.rs
@@ -8,42 +8,42 @@ use zerocopy::{FromBytes, Immutable, KnownLayout};
 #[derive(Clone, PartialEq, Debug, FromBytes, Immutable, KnownLayout)]
 pub struct Header {
     /// Total message size in halfwords, including the header and all elevation blocks
-    pub(crate) message_size: Integer2,
+    pub message_size: Integer2,
 
     /// Pattern type is always 2
-    pub(crate) pattern_type: Code2,
+    pub pattern_type: Code2,
 
     /// Volume Coverage Pattern Number
-    pub(crate) pattern_number: Integer2,
+    pub pattern_number: Integer2,
 
     /// Number of elevation cuts in the complete volume scan
-    pub(crate) number_of_elevation_cuts: Integer2,
+    pub number_of_elevation_cuts: Integer2,
 
     /// Volume Coverage Pattern Version Number
-    pub(crate) version: Integer1,
+    pub version: Integer1,
 
     /// Clutter map groups are not currently implemented
-    pub(crate) clutter_map_group_number: Integer1,
+    pub clutter_map_group_number: Integer1,
 
     /// Doppler velocity resolution.
     /// 2 -> 0.5
     /// 4 -> 1.0
-    pub(crate) doppler_velocity_resolution: Code1,
+    pub doppler_velocity_resolution: Code1,
 
     /// Pulse width values.
     /// 2 -> Short
     /// 4 -> Long
-    pub(crate) pulse_width: Code1,
+    pub pulse_width: Code1,
 
     /// Reserved
-    pub(crate) reserved_1: Integer4,
+    pub reserved_1: Integer4,
 
     /// VCP sequencing values.
     /// Bits 0-4: Number of Elevations
     /// Bits 5-6: Maximum SAILS Cuts
     /// Bit  13:  Sequence Active
     /// Bit  14:  Truncated VCP
-    pub(crate) vcp_sequencing: Code2,
+    pub vcp_sequencing: Code2,
 
     /// VCP supplemental data.
     /// Bit  0:     SAILS VCP
@@ -54,8 +54,8 @@ pub struct Header {
     /// Bit  11:    MPDA VCP
     /// Bit  12:    BASE TILT VCP
     /// Bits 13-15: Number of BASE TILTS
-    pub(crate) vcp_supplemental_data: Code2,
+    pub vcp_supplemental_data: Code2,
 
     /// Reserved
-    pub(crate) reserved_2: Integer2,
+    pub reserved_2: Integer2,
 }

--- a/nexrad-decode/src/messages/volume_coverage_pattern/raw/mod.rs
+++ b/nexrad-decode/src/messages/volume_coverage_pattern/raw/mod.rs
@@ -1,5 +1,5 @@
-pub(crate) mod header;
-pub(crate) use header::Header;
+mod header;
+pub use header::Header;
 
-pub(crate) mod elevation_data_block;
-pub(crate) use elevation_data_block::{decode_angle, decode_angular_velocity, ElevationDataBlock};
+mod elevation_data_block;
+pub use elevation_data_block::{decode_angle, decode_angular_velocity, ElevationDataBlock};


### PR DESCRIPTION
Simplifies private types' publicity to just `pub`, trusting the parent `mod` to encapsulate properly.

Closes #87