### PR TITLE
Fix live decode test

### DIFF
--- a/.github/workflows/live-decode.yml
+++ b/.github/workflows/live-decode.yml
@@ -26,7 +26,8 @@ jobs:
         env:
           TEST_SITE: ${{ matrix.site }}
         run: |
-          cargo test --package nexrad-data --test live_decode test_live_decode_${{ matrix.site }} \
+          SITE_LOWER=$(echo "${{ matrix.site }}" | tr '[:upper:]' '[:lower:]')
+          cargo test --package nexrad-data --test live_decode "test_live_decode_${SITE_LOWER}" \
             --features aws -- --ignored --nocapture
 
   notify-failure:


### PR DESCRIPTION
Our weekly download and decode tests are not working due to a test name mismatch. The workflow matrix uses uppercase site names (KDMX, KTLX, etc.), producing a cargo test filter like `test_live_decode_KDMX`. But the Rust test functions are lowercase (`test_live_decode_kdmx`). Cargo's test name filtering is case-sensitive, so zero tests matched and all 6 were filtered out.

Fix in `live-decode.yml:29-30`: Lowercase the matrix site variable before using it in the test filter.

Closes #138.